### PR TITLE
Update to 1.12

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,8 @@ version_major=1
 version_minor=7
 version_micro=8
 version_minecraft=1.12
-version_forge=14.21.0.2343
-version_minforge=14.21.0.2343
+version_forge=14.21.0.2373
+version_minforge=14.21.0.2373
 version_mappings=snapshot_20170621
 version_lunatriuscore=1.1.3
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,11 +1,11 @@
 version_major=1
 version_minor=7
 version_micro=8
-version_minecraft=1.11
-version_forge=13.19.0.2177
-version_minforge=13.19.0.2172
-version_mappings=snapshot_20161203
-version_lunatriuscore=1.1.2.39
+version_minecraft=1.12
+version_forge=14.21.0.2343
+version_minforge=14.21.0.2343
+version_mappings=snapshot_20170621
+version_lunatriuscore=1.1.3
 
 extra_modsio_id=1008
 extra_curseforge_id=225603

--- a/src/main/java/com/github/lunatrius/schematica/block/state/pattern/BlockStateReplacer.java
+++ b/src/main/java/com/github/lunatrius/schematica/block/state/pattern/BlockStateReplacer.java
@@ -58,6 +58,9 @@ public class BlockStateReplacer {
                 public boolean apply(final Comparable input) {
                     return input != null && input.equals(entry.getValue());
                 }
+                public boolean test(final Comparable input) {
+                    return false;
+                }
             });
         }
 

--- a/src/main/java/com/github/lunatrius/schematica/block/state/pattern/BlockStateReplacer.java
+++ b/src/main/java/com/github/lunatrius/schematica/block/state/pattern/BlockStateReplacer.java
@@ -8,15 +8,12 @@ import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.block.state.pattern.BlockStateMatcher;
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.fml.common.registry.FMLControlledNamespacedRegistry;
-import net.minecraftforge.fml.common.registry.GameData;
 
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
 public class BlockStateReplacer {
-    private static final FMLControlledNamespacedRegistry<Block> BLOCK_REGISTRY = GameData.getBlockRegistry();
     private final IBlockState defaultReplacement;
 
     private BlockStateReplacer(final IBlockState defaultReplacement) {
@@ -83,11 +80,11 @@ public class BlockStateReplacer {
         }
 
         final ResourceLocation location = new ResourceLocation(blockName);
-        if (!BLOCK_REGISTRY.containsKey(location)) {
+        if (Block.REGISTRY.containsKey(location)) {
             throw new LocalizedException(Names.Messages.INVALID_BLOCK, blockName);
         }
 
-        final Block block = BLOCK_REGISTRY.getObject(location);
+        final Block block = Block.REGISTRY.getObject(location);
         final Map<IProperty, Comparable> propertyData = parsePropertyData(block.getDefaultState(), stateData, true);
         return new BlockStateInfo(block, propertyData);
     }
@@ -127,7 +124,7 @@ public class BlockStateReplacer {
         }
 
         if (strict) {
-            throw new LocalizedException(Names.Messages.INVALID_PROPERTY_FOR_BLOCK, name + "=" + value, BLOCK_REGISTRY.getNameForObject(blockState.getBlock()));
+            throw new LocalizedException(Names.Messages.INVALID_PROPERTY_FOR_BLOCK, name + "=" + value, Block.REGISTRY.getNameForObject(blockState.getBlock()));
         }
 
         return false;

--- a/src/main/java/com/github/lunatrius/schematica/client/gui/config/GuiFactory.java
+++ b/src/main/java/com/github/lunatrius/schematica/client/gui/config/GuiFactory.java
@@ -16,17 +16,7 @@ public class GuiFactory implements IModGuiFactory {
     }
 
     @Override
-    public Class<? extends GuiScreen> mainConfigGuiClass() {
-        return GuiModConfig.class;
-    }
-
-    @Override
     public Set<RuntimeOptionCategoryElement> runtimeGuiCategories() {
-        return null;
-    }
-
-    @Override
-    public RuntimeOptionGuiHandler getHandlerFor(final RuntimeOptionCategoryElement element) {
         return null;
     }
 

--- a/src/main/java/com/github/lunatrius/schematica/client/gui/config/GuiFactory.java
+++ b/src/main/java/com/github/lunatrius/schematica/client/gui/config/GuiFactory.java
@@ -35,4 +35,16 @@ public class GuiFactory implements IModGuiFactory {
             super(guiScreen, Reference.MODID, ConfigurationHandler.configuration, Names.Config.LANG_PREFIX);
         }
     }
+
+	@Override
+	public GuiScreen createConfigGui(GuiScreen arg0) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public boolean hasConfigGui() {
+		// TODO Auto-generated method stub
+		return false;
+	}
 }

--- a/src/main/java/com/github/lunatrius/schematica/client/gui/control/GuiSchematicControl.java
+++ b/src/main/java/com/github/lunatrius/schematica/client/gui/control/GuiSchematicControl.java
@@ -75,13 +75,13 @@ public class GuiSchematicControl extends GuiScreenBase {
 
         int id = 0;
 
-        this.numericX = new GuiNumericField(this.fontRendererObj, id++, this.centerX - 50, this.centerY - 30, 100, 20);
+        this.numericX = new GuiNumericField(this.fontRenderer, id++, this.centerX - 50, this.centerY - 30, 100, 20);
         this.buttonList.add(this.numericX);
 
-        this.numericY = new GuiNumericField(this.fontRendererObj, id++, this.centerX - 50, this.centerY - 5, 100, 20);
+        this.numericY = new GuiNumericField(this.fontRenderer, id++, this.centerX - 50, this.centerY - 5, 100, 20);
         this.buttonList.add(this.numericY);
 
-        this.numericZ = new GuiNumericField(this.fontRendererObj, id++, this.centerX - 50, this.centerY + 20, 100, 20);
+        this.numericZ = new GuiNumericField(this.fontRenderer, id++, this.centerX - 50, this.centerY + 20, 100, 20);
         this.buttonList.add(this.numericZ);
 
         this.btnUnload = new GuiButton(id++, this.width - 90, this.height - 200, 80, 20, this.strUnload);
@@ -90,7 +90,7 @@ public class GuiSchematicControl extends GuiScreenBase {
         this.btnLayerMode = new GuiButton(id++, this.width - 90, this.height - 150 - 25, 80, 20, this.schematic != null && this.schematic.isRenderingLayer ? this.strLayers : this.strAll);
         this.buttonList.add(this.btnLayerMode);
 
-        this.nfLayer = new GuiNumericField(this.fontRendererObj, id++, this.width - 90, this.height - 150, 80, 20);
+        this.nfLayer = new GuiNumericField(this.fontRenderer, id++, this.width - 90, this.height - 150, 80, 20);
         this.buttonList.add(this.nfLayer);
 
         this.btnHide = new GuiButton(id++, this.width - 90, this.height - 105, 80, 20, this.schematic != null && this.schematic.isRendering ? this.strHide : this.strShow);
@@ -238,15 +238,15 @@ public class GuiSchematicControl extends GuiScreenBase {
     public void drawScreen(final int par1, final int par2, final float par3) {
         // drawDefaultBackground();
 
-        drawCenteredString(this.fontRendererObj, this.strMoveSchematic, this.centerX, this.centerY - 45, 0xFFFFFF);
-        drawCenteredString(this.fontRendererObj, this.strMaterials, 50, this.height - 85, 0xFFFFFF);
-        drawCenteredString(this.fontRendererObj, this.strPrinter, 50, this.height - 45, 0xFFFFFF);
-        drawCenteredString(this.fontRendererObj, this.strLayers, this.width - 50, this.height - 165, 0xFFFFFF);
-        drawCenteredString(this.fontRendererObj, this.strOperations, this.width - 50, this.height - 120, 0xFFFFFF);
+        drawCenteredString(this.fontRenderer, this.strMoveSchematic, this.centerX, this.centerY - 45, 0xFFFFFF);
+        drawCenteredString(this.fontRenderer, this.strMaterials, 50, this.height - 85, 0xFFFFFF);
+        drawCenteredString(this.fontRenderer, this.strPrinter, 50, this.height - 45, 0xFFFFFF);
+        drawCenteredString(this.fontRenderer, this.strLayers, this.width - 50, this.height - 165, 0xFFFFFF);
+        drawCenteredString(this.fontRenderer, this.strOperations, this.width - 50, this.height - 120, 0xFFFFFF);
 
-        drawString(this.fontRendererObj, this.strX, this.centerX - 65, this.centerY - 24, 0xFFFFFF);
-        drawString(this.fontRendererObj, this.strY, this.centerX - 65, this.centerY + 1, 0xFFFFFF);
-        drawString(this.fontRendererObj, this.strZ, this.centerX - 65, this.centerY + 26, 0xFFFFFF);
+        drawString(this.fontRenderer, this.strX, this.centerX - 65, this.centerY - 24, 0xFFFFFF);
+        drawString(this.fontRenderer, this.strY, this.centerX - 65, this.centerY + 1, 0xFFFFFF);
+        drawString(this.fontRenderer, this.strZ, this.centerX - 65, this.centerY + 26, 0xFFFFFF);
 
         super.drawScreen(par1, par2, par3);
     }

--- a/src/main/java/com/github/lunatrius/schematica/client/gui/control/GuiSchematicMaterials.java
+++ b/src/main/java/com/github/lunatrius/schematica/client/gui/control/GuiSchematicMaterials.java
@@ -97,8 +97,8 @@ public class GuiSchematicMaterials extends GuiScreenBase {
     public void drawScreen(final int x, final int y, final float partialTicks) {
         this.guiSchematicMaterialsSlot.drawScreen(x, y, partialTicks);
 
-        drawString(this.fontRendererObj, this.strMaterialName, this.width / 2 - 108, 4, 0x00FFFFFF);
-        drawString(this.fontRendererObj, this.strMaterialAmount, this.width / 2 + 108 - this.fontRendererObj.getStringWidth(this.strMaterialAmount), 4, 0x00FFFFFF);
+        drawString(this.fontRenderer, this.strMaterialName, this.width / 2 - 108, 4, 0x00FFFFFF);
+        drawString(this.fontRenderer, this.strMaterialAmount, this.width / 2 + 108 - this.fontRenderer.getStringWidth(this.strMaterialAmount), 4, 0x00FFFFFF);
         super.drawScreen(x, y, partialTicks);
     }
 

--- a/src/main/java/com/github/lunatrius/schematica/client/gui/control/GuiSchematicMaterialsSlot.java
+++ b/src/main/java/com/github/lunatrius/schematica/client/gui/control/GuiSchematicMaterialsSlot.java
@@ -55,7 +55,7 @@ class GuiSchematicMaterialsSlot extends GuiSlot {
     }
 
     @Override
-    protected void drawSlot(final int index, final int x, final int y, final int par4, final int mouseX, final int mouseY) {
+    protected void drawSlot(final int index, final int x, final int y, final int par4, final int mouseX, final int mouseY, final float par6) {
         final BlockList.WrappedItemStack wrappedItemStack = this.guiSchematicMaterials.blockList.get(index);
         final ItemStack itemStack = wrappedItemStack.itemStack;
 
@@ -65,9 +65,9 @@ class GuiSchematicMaterialsSlot extends GuiSlot {
 
         GuiHelper.drawItemStackWithSlot(this.minecraft.renderEngine, itemStack, x, y);
 
-        this.guiSchematicMaterials.drawString(this.minecraft.fontRendererObj, itemName, x + 24, y + 6, 0xFFFFFF);
-        this.guiSchematicMaterials.drawString(this.minecraft.fontRendererObj, amount, x + 215 - this.minecraft.fontRendererObj.getStringWidth(amount), y + 1, 0xFFFFFF);
-        this.guiSchematicMaterials.drawString(this.minecraft.fontRendererObj, amountMissing, x + 215 - this.minecraft.fontRendererObj.getStringWidth(amountMissing), y + 11, 0xFFFFFF);
+        this.guiSchematicMaterials.drawString(this.minecraft.fontRenderer, itemName, x + 24, y + 6, 0xFFFFFF);
+        this.guiSchematicMaterials.drawString(this.minecraft.fontRenderer, amount, x + 215 - this.minecraft.fontRenderer.getStringWidth(amount), y + 1, 0xFFFFFF);
+        this.guiSchematicMaterials.drawString(this.minecraft.fontRenderer, amountMissing, x + 215 - this.minecraft.fontRenderer.getStringWidth(amountMissing), y + 11, 0xFFFFFF);
 
         if (mouseX > x && mouseY > y && mouseX <= x + 18 && mouseY <= y + 18) {
             this.guiSchematicMaterials.renderToolTip(itemStack, mouseX, mouseY);

--- a/src/main/java/com/github/lunatrius/schematica/client/gui/load/GuiSchematicLoad.java
+++ b/src/main/java/com/github/lunatrius/schematica/client/gui/load/GuiSchematicLoad.java
@@ -97,8 +97,8 @@ public class GuiSchematicLoad extends GuiScreenBase {
     public void drawScreen(final int x, final int y, final float partialTicks) {
         this.guiSchematicLoadSlot.drawScreen(x, y, partialTicks);
 
-        drawCenteredString(this.fontRendererObj, this.strTitle, this.width / 2, 4, 0x00FFFFFF);
-        drawCenteredString(this.fontRendererObj, this.strFolderInfo, this.width / 2 - 78, this.height - 12, 0x00808080);
+        drawCenteredString(this.fontRenderer, this.strTitle, this.width / 2, 4, 0x00FFFFFF);
+        drawCenteredString(this.fontRenderer, this.strFolderInfo, this.width / 2 - 78, this.height - 12, 0x00808080);
 
         super.drawScreen(x, y, partialTicks);
     }

--- a/src/main/java/com/github/lunatrius/schematica/client/gui/load/GuiSchematicLoadSlot.java
+++ b/src/main/java/com/github/lunatrius/schematica/client/gui/load/GuiSchematicLoadSlot.java
@@ -55,7 +55,7 @@ public class GuiSchematicLoadSlot extends GuiSlot {
     }
 
     @Override
-    protected void drawSlot(final int index, final int x, final int y, final int par4, final int mouseX, final int mouseY) {
+    protected void drawSlot(final int index, final int x, final int y, final int par4, final int mouseX, final int mouseY, final float arg6) {
         if (index < 0 || index >= this.guiSchematicLoad.schematicFiles.size()) {
             return;
         }
@@ -71,6 +71,6 @@ public class GuiSchematicLoadSlot extends GuiSlot {
 
         GuiHelper.drawItemStackWithSlot(this.minecraft.renderEngine, schematic.getItemStack(), x, y);
 
-        this.guiSchematicLoad.drawString(this.minecraft.fontRendererObj, schematicName, x + 24, y + 6, 0x00FFFFFF);
+        this.guiSchematicLoad.drawString(this.minecraft.fontRenderer, schematicName, x + 24, y + 6, 0x00FFFFFF);
     }
 }

--- a/src/main/java/com/github/lunatrius/schematica/client/gui/save/GuiSchematicSave.java
+++ b/src/main/java/com/github/lunatrius/schematica/client/gui/save/GuiSchematicSave.java
@@ -62,31 +62,31 @@ public class GuiSchematicSave extends GuiScreenBase {
         this.btnPointA = new GuiButton(id++, this.centerX - 130, this.centerY - 55, 100, 20, I18n.format(Names.Gui.Save.POINT_RED));
         this.buttonList.add(this.btnPointA);
 
-        this.numericAX = new GuiNumericField(this.fontRendererObj, id++, this.centerX - 130, this.centerY - 30);
+        this.numericAX = new GuiNumericField(this.fontRenderer, id++, this.centerX - 130, this.centerY - 30);
         this.buttonList.add(this.numericAX);
 
-        this.numericAY = new GuiNumericField(this.fontRendererObj, id++, this.centerX - 130, this.centerY - 5);
+        this.numericAY = new GuiNumericField(this.fontRenderer, id++, this.centerX - 130, this.centerY - 5);
         this.buttonList.add(this.numericAY);
 
-        this.numericAZ = new GuiNumericField(this.fontRendererObj, id++, this.centerX - 130, this.centerY + 20);
+        this.numericAZ = new GuiNumericField(this.fontRenderer, id++, this.centerX - 130, this.centerY + 20);
         this.buttonList.add(this.numericAZ);
 
         this.btnPointB = new GuiButton(id++, this.centerX + 30, this.centerY - 55, 100, 20, I18n.format(Names.Gui.Save.POINT_BLUE));
         this.buttonList.add(this.btnPointB);
 
-        this.numericBX = new GuiNumericField(this.fontRendererObj, id++, this.centerX + 30, this.centerY - 30);
+        this.numericBX = new GuiNumericField(this.fontRenderer, id++, this.centerX + 30, this.centerY - 30);
         this.buttonList.add(this.numericBX);
 
-        this.numericBY = new GuiNumericField(this.fontRendererObj, id++, this.centerX + 30, this.centerY - 5);
+        this.numericBY = new GuiNumericField(this.fontRenderer, id++, this.centerX + 30, this.centerY - 5);
         this.buttonList.add(this.numericBY);
 
-        this.numericBZ = new GuiNumericField(this.fontRendererObj, id++, this.centerX + 30, this.centerY + 20);
+        this.numericBZ = new GuiNumericField(this.fontRenderer, id++, this.centerX + 30, this.centerY + 20);
         this.buttonList.add(this.numericBZ);
 
         this.btnEnable = new GuiButton(id++, this.width - 210, this.height - 30, 50, 20, ClientProxy.isRenderingGuide && Schematica.proxy.isSaveEnabled ? this.strOn : this.strOff);
         this.buttonList.add(this.btnEnable);
 
-        this.tfFilename = new GuiTextField(id++, this.fontRendererObj, this.width - 155, this.height - 29, 100, 18);
+        this.tfFilename = new GuiTextField(id++, this.fontRenderer, this.width - 155, this.height - 29, 100, 18);
         this.textFields.add(this.tfFilename);
 
         this.btnSave = new GuiButton(id++, this.width - 50, this.height - 30, 40, 20, I18n.format(Names.Gui.Save.SAVE));
@@ -175,25 +175,25 @@ public class GuiSchematicSave extends GuiScreenBase {
     public void drawScreen(final int par1, final int par2, final float par3) {
         // drawDefaultBackground();
 
-        drawString(this.fontRendererObj, this.strSaveSelection, this.width - 205, this.height - 45, 0xFFFFFF);
+        drawString(this.fontRenderer, this.strSaveSelection, this.width - 205, this.height - 45, 0xFFFFFF);
 
-        drawString(this.fontRendererObj, this.strX, this.centerX - 145, this.centerY - 24, 0xFFFFFF);
-        drawString(this.fontRendererObj, Integer.toString(ClientProxy.pointA.x), this.centerX - 25, this.centerY - 24, 0xFFFFFF);
+        drawString(this.fontRenderer, this.strX, this.centerX - 145, this.centerY - 24, 0xFFFFFF);
+        drawString(this.fontRenderer, Integer.toString(ClientProxy.pointA.x), this.centerX - 25, this.centerY - 24, 0xFFFFFF);
 
-        drawString(this.fontRendererObj, this.strY, this.centerX - 145, this.centerY + 1, 0xFFFFFF);
-        drawString(this.fontRendererObj, Integer.toString(ClientProxy.pointA.y), this.centerX - 25, this.centerY + 1, 0xFFFFFF);
+        drawString(this.fontRenderer, this.strY, this.centerX - 145, this.centerY + 1, 0xFFFFFF);
+        drawString(this.fontRenderer, Integer.toString(ClientProxy.pointA.y), this.centerX - 25, this.centerY + 1, 0xFFFFFF);
 
-        drawString(this.fontRendererObj, this.strZ, this.centerX - 145, this.centerY + 26, 0xFFFFFF);
-        drawString(this.fontRendererObj, Integer.toString(ClientProxy.pointA.z), this.centerX - 25, this.centerY + 26, 0xFFFFFF);
+        drawString(this.fontRenderer, this.strZ, this.centerX - 145, this.centerY + 26, 0xFFFFFF);
+        drawString(this.fontRenderer, Integer.toString(ClientProxy.pointA.z), this.centerX - 25, this.centerY + 26, 0xFFFFFF);
 
-        drawString(this.fontRendererObj, this.strX, this.centerX + 15, this.centerY - 24, 0xFFFFFF);
-        drawString(this.fontRendererObj, Integer.toString(ClientProxy.pointB.x), this.centerX + 135, this.centerY - 24, 0xFFFFFF);
+        drawString(this.fontRenderer, this.strX, this.centerX + 15, this.centerY - 24, 0xFFFFFF);
+        drawString(this.fontRenderer, Integer.toString(ClientProxy.pointB.x), this.centerX + 135, this.centerY - 24, 0xFFFFFF);
 
-        drawString(this.fontRendererObj, this.strY, this.centerX + 15, this.centerY + 1, 0xFFFFFF);
-        drawString(this.fontRendererObj, Integer.toString(ClientProxy.pointB.y), this.centerX + 135, this.centerY + 1, 0xFFFFFF);
+        drawString(this.fontRenderer, this.strY, this.centerX + 15, this.centerY + 1, 0xFFFFFF);
+        drawString(this.fontRenderer, Integer.toString(ClientProxy.pointB.y), this.centerX + 135, this.centerY + 1, 0xFFFFFF);
 
-        drawString(this.fontRendererObj, this.strZ, this.centerX + 15, this.centerY + 26, 0xFFFFFF);
-        drawString(this.fontRendererObj, Integer.toString(ClientProxy.pointB.z), this.centerX + 135, this.centerY + 26, 0xFFFFFF);
+        drawString(this.fontRenderer, this.strZ, this.centerX + 15, this.centerY + 26, 0xFFFFFF);
+        drawString(this.fontRenderer, Integer.toString(ClientProxy.pointB.z), this.centerX + 135, this.centerY + 26, 0xFFFFFF);
 
         super.drawScreen(par1, par2, par3);
     }

--- a/src/main/java/com/github/lunatrius/schematica/client/renderer/RenderSchematic.java
+++ b/src/main/java/com/github/lunatrius/schematica/client/renderer/RenderSchematic.java
@@ -23,12 +23,12 @@ import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.client.multiplayer.WorldClient;
+import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.RenderGlobal;
 import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.VertexBuffer;
 import net.minecraft.client.renderer.chunk.ChunkRenderDispatcher;
 import net.minecraft.client.renderer.chunk.CompiledChunk;
 import net.minecraft.client.renderer.chunk.RenderChunk;
@@ -450,8 +450,8 @@ public class RenderSchematic extends RenderGlobal {
         final int entityPass = 0;
 
         this.profiler.startSection("prepare");
-        TileEntityRendererDispatcher.instance.prepare(this.world, this.mc.getTextureManager(), this.mc.fontRendererObj, renderViewEntity, this.mc.objectMouseOver, partialTicks);
-        this.renderManager.cacheActiveRenderInfo(this.world, this.mc.fontRendererObj, renderViewEntity, this.mc.pointedEntity, this.mc.gameSettings, partialTicks);
+        TileEntityRendererDispatcher.instance.prepare(this.world, this.mc.getTextureManager(), this.mc.fontRenderer, renderViewEntity, this.mc.objectMouseOver, partialTicks);
+        this.renderManager.cacheActiveRenderInfo(this.world, this.mc.fontRenderer, renderViewEntity, this.mc.pointedEntity, this.mc.gameSettings, partialTicks);
 
         this.countEntitiesTotal = 0;
         this.countEntitiesRendered = 0;
@@ -491,7 +491,7 @@ public class RenderSchematic extends RenderGlobal {
                     continue;
                 }
 
-                TileEntityRendererDispatcher.instance.renderTileEntity(tileEntity, partialTicks, -1);
+                TileEntityRendererDispatcher.instance.render(tileEntity, partialTicks, -1);
                 this.countTileEntitiesRendered++;
             }
         }
@@ -660,13 +660,13 @@ public class RenderSchematic extends RenderGlobal {
             final RenderChunk renderChunk = renderInfo.renderChunk;
             final RenderOverlay renderOverlay = renderInfo.renderOverlay;
 
-            if (renderChunk.isNeedsUpdate() || set.contains(renderChunk)) {
+            if (renderChunk.needsUpdate() || set.contains(renderChunk)) {
                 this.displayListEntitiesDirty = true;
 
                 this.chunksToUpdate.add(renderChunk);
             }
 
-            if (renderOverlay.isNeedsUpdate() || set1.contains(renderOverlay)) {
+            if (renderOverlay.needsUpdate() || set1.contains(renderOverlay)) {
                 this.displayListEntitiesDirty = true;
 
                 this.overlaysToUpdate.add(renderOverlay);
@@ -808,10 +808,6 @@ public class RenderSchematic extends RenderGlobal {
     }
 
     @Override
-    public void renderClouds(final float partialTicks, final int pass) {
-    }
-
-    @Override
     public boolean hasCloudFog(final double x, final double y, final double z, final float partialTicks) {
         return false;
     }
@@ -859,7 +855,7 @@ public class RenderSchematic extends RenderGlobal {
     public void renderWorldBorder(final Entity entity, final float partialTicks) {}
 
     @Override
-    public void drawBlockDamageTexture(final Tessellator tessellator, final VertexBuffer buffer, final Entity entity, final float partialTicks) {}
+    public void drawBlockDamageTexture(final Tessellator tessellator, final BufferBuilder buffer, final Entity entity, final float partialTicks) {}
 
     @Override
     public void drawSelectionBox(final EntityPlayer player, final RayTraceResult rayTraceResult, final int execute, final float partialTicks) {}

--- a/src/main/java/com/github/lunatrius/schematica/client/renderer/chunk/OverlayRenderDispatcher.java
+++ b/src/main/java/com/github/lunatrius/schematica/client/renderer/chunk/OverlayRenderDispatcher.java
@@ -4,8 +4,8 @@ import com.github.lunatrius.schematica.client.renderer.chunk.overlay.RenderOverl
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.OpenGlHelper;
-import net.minecraft.client.renderer.VertexBuffer;
 import net.minecraft.client.renderer.chunk.ChunkRenderDispatcher;
 import net.minecraft.client.renderer.chunk.CompiledChunk;
 import net.minecraft.client.renderer.chunk.RenderChunk;
@@ -21,7 +21,7 @@ public class OverlayRenderDispatcher extends ChunkRenderDispatcher {
     }
 
     @Override
-    public ListenableFuture<Object> uploadChunk(final BlockRenderLayer layer, final VertexBuffer buffer, final RenderChunk renderChunk, final CompiledChunk compiledChunk, final double distanceSq) {
+    public ListenableFuture<Object> uploadChunk(final BlockRenderLayer layer, final BufferBuilder buffer, final RenderChunk renderChunk, final CompiledChunk compiledChunk, final double distanceSq) {
         if (!Minecraft.getMinecraft().isCallingFromMinecraftThread() || OpenGlHelper.useVbo()) {
             return super.uploadChunk(layer, buffer, renderChunk, compiledChunk, distanceSq);
         }

--- a/src/main/java/com/github/lunatrius/schematica/client/renderer/chunk/overlay/RenderOverlay.java
+++ b/src/main/java/com/github/lunatrius/schematica/client/renderer/chunk/overlay/RenderOverlay.java
@@ -8,6 +8,7 @@ import com.github.lunatrius.schematica.handler.ConfigurationHandler;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.RenderGlobal;
 import net.minecraft.client.renderer.chunk.ChunkCompileTaskGenerator;
@@ -63,13 +64,13 @@ public class RenderOverlay extends RenderChunk {
 
         final VisGraph visgraph = new VisGraph();
 
-        if (!chunkCache.extendedLevelsInChunkCache()) {
+        if (!chunkCache.isEmpty()) {
             ++renderChunksUpdated;
 
             final World mcWorld = Minecraft.getMinecraft().world;
 
             final BlockRenderLayer layer = BlockRenderLayer.TRANSLUCENT;
-            final net.minecraft.client.renderer.VertexBuffer buffer = generator.getRegionRenderCacheBuilder().getWorldRendererByLayer(layer);
+            final net.minecraft.client.renderer.BufferBuilder buffer = generator.getRegionRenderCacheBuilder().getWorldRendererByLayer(layer);
 
             GeometryTessellator.setStaticDelta(ConfigurationHandler.blockDelta);
 
@@ -174,7 +175,7 @@ public class RenderOverlay extends RenderChunk {
     }
 
     @Override
-    public void preRenderBlocks(final net.minecraft.client.renderer.VertexBuffer buffer, final BlockPos pos) {
+    public void preRenderBlocks(final net.minecraft.client.renderer.BufferBuilder buffer, final BlockPos pos) {
         buffer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_COLOR);
         buffer.setTranslation(-pos.getX(), -pos.getY(), -pos.getZ());
     }

--- a/src/main/java/com/github/lunatrius/schematica/client/util/FlipHelper.java
+++ b/src/main/java/com/github/lunatrius/schematica/client/util/FlipHelper.java
@@ -17,15 +17,11 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3i;
-import net.minecraftforge.fml.common.registry.FMLControlledNamespacedRegistry;
-import net.minecraftforge.fml.common.registry.GameData;
 
 import java.util.List;
 
 public class FlipHelper {
     public static final FlipHelper INSTANCE = new FlipHelper();
-
-    private static final FMLControlledNamespacedRegistry<Block> BLOCK_REGISTRY = GameData.getBlockRegistry();
 
     public boolean flip(final SchematicWorld world, final EnumFacing axis, final boolean forced) {
         if (world == null) {
@@ -111,11 +107,11 @@ public class FlipHelper {
                 }
             }
         } else if (propertyFacing != null) {
-            Reference.logger.error("'{}': found 'facing' property with unknown type {}", BLOCK_REGISTRY.getNameForObject(blockState.getBlock()), propertyFacing.getClass().getSimpleName());
+            Reference.logger.error("'{}': found 'facing' property with unknown type {}", Block.REGISTRY.getNameForObject(blockState.getBlock()), propertyFacing.getClass().getSimpleName());
         }
 
         if (!forced && propertyFacing != null) {
-            throw new FlipException("'%s' cannot be flipped across '%s'", BLOCK_REGISTRY.getNameForObject(blockState.getBlock()), axis);
+            throw new FlipException("'%s' cannot be flipped across '%s'", Block.REGISTRY.getNameForObject(blockState.getBlock()), axis);
         }
 
         return blockState;

--- a/src/main/java/com/github/lunatrius/schematica/client/util/RotationHelper.java
+++ b/src/main/java/com/github/lunatrius/schematica/client/util/RotationHelper.java
@@ -19,15 +19,12 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3i;
-import net.minecraftforge.fml.common.registry.FMLControlledNamespacedRegistry;
-import net.minecraftforge.fml.common.registry.GameData;
 
 import java.util.List;
 
 public class RotationHelper {
     public static final RotationHelper INSTANCE = new RotationHelper();
 
-    private static final FMLControlledNamespacedRegistry<Block> BLOCK_REGISTRY = GameData.getBlockRegistry();
     private static final EnumFacing[][] FACINGS = new EnumFacing[EnumFacing.VALUES.length][];
     private static final EnumFacing.Axis[][] AXISES = new EnumFacing.Axis[EnumFacing.Axis.values().length][];
     private static final BlockLog.EnumAxis[][] AXISES_LOG = new BlockLog.EnumAxis[EnumFacing.Axis.values().length][];
@@ -171,7 +168,7 @@ public class RotationHelper {
                 }
             }
         } else if (propertyFacing != null) {
-            Reference.logger.error("'{}': found 'facing' property with unknown type {}", BLOCK_REGISTRY.getNameForObject(blockState.getBlock()), propertyFacing.getClass().getSimpleName());
+            Reference.logger.error("'{}': found 'facing' property with unknown type {}", Block.REGISTRY.getNameForObject(blockState.getBlock()), propertyFacing.getClass().getSimpleName());
         }
 
         final IProperty propertyAxis = BlockStateHelper.getProperty(blockState, "axis");
@@ -188,7 +185,7 @@ public class RotationHelper {
                 return blockState.withProperty(propertyAxis, axisRotated);
             }
         } else if (propertyAxis != null) {
-            Reference.logger.error("'{}': found 'axis' property with unknown type {}", BLOCK_REGISTRY.getNameForObject(blockState.getBlock()), propertyAxis.getClass().getSimpleName());
+            Reference.logger.error("'{}': found 'axis' property with unknown type {}", Block.REGISTRY.getNameForObject(blockState.getBlock()), propertyAxis.getClass().getSimpleName());
         }
 
         final IProperty propertyVariant = BlockStateHelper.getProperty(blockState, "variant");
@@ -201,7 +198,7 @@ public class RotationHelper {
         }
 
         if (!forced && (propertyFacing != null || propertyAxis != null)) {
-            throw new RotationException("'%s' cannot be rotated around '%s'", BLOCK_REGISTRY.getNameForObject(blockState.getBlock()), axisRotation);
+            throw new RotationException("'%s' cannot be rotated around '%s'", Block.REGISTRY.getNameForObject(blockState.getBlock()), axisRotation);
         }
 
         return blockState;

--- a/src/main/java/com/github/lunatrius/schematica/client/world/chunk/ChunkProviderSchematic.java
+++ b/src/main/java/com/github/lunatrius/schematica/client/world/chunk/ChunkProviderSchematic.java
@@ -1,6 +1,7 @@
 package com.github.lunatrius.schematica.client.world.chunk;
 
 import com.github.lunatrius.schematica.client.world.SchematicWorld;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import net.minecraft.client.multiplayer.ChunkProviderClient;
 import net.minecraft.util.math.ChunkPos;
@@ -64,7 +65,7 @@ public class ChunkProviderSchematic extends ChunkProviderClient implements IChun
     // ChunkProviderClient
     @Override
     public Chunk loadChunk(int x, int z) {
-        return Objects.firstNonNull(getLoadedChunk(x, z), this.emptyChunk);
+        return MoreObjects.firstNonNull(getLoadedChunk(x, z), this.emptyChunk);
     }
 
     // ChunkProviderClient

--- a/src/main/java/com/github/lunatrius/schematica/client/world/chunk/ChunkProviderSchematic.java
+++ b/src/main/java/com/github/lunatrius/schematica/client/world/chunk/ChunkProviderSchematic.java
@@ -2,7 +2,6 @@ package com.github.lunatrius.schematica.client.world.chunk;
 
 import com.github.lunatrius.schematica.client.world.SchematicWorld;
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 import net.minecraft.client.multiplayer.ChunkProviderClient;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.chunk.Chunk;

--- a/src/main/java/com/github/lunatrius/schematica/client/world/chunk/ChunkSchematic.java
+++ b/src/main/java/com/github/lunatrius/schematica/client/world/chunk/ChunkSchematic.java
@@ -28,7 +28,7 @@ public class ChunkSchematic extends Chunk {
     }
 
     @Override
-    public boolean getAreLevelsEmpty(final int startY, final int endY) {
+    public boolean isEmptyBetween(final int startY, final int endY) {
         return false;
     }
 

--- a/src/main/java/com/github/lunatrius/schematica/command/client/CommandSchematicaReplace.java
+++ b/src/main/java/com/github/lunatrius/schematica/command/client/CommandSchematicaReplace.java
@@ -13,13 +13,10 @@ import net.minecraft.command.ICommandSender;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.TextComponentTranslation;
-import net.minecraftforge.fml.common.registry.FMLControlledNamespacedRegistry;
-import net.minecraftforge.fml.common.registry.GameData;
 
 import java.util.List;
 
 public class CommandSchematicaReplace extends CommandSchematicaBase {
-    private static final FMLControlledNamespacedRegistry<Block> BLOCK_REGISTRY = GameData.getBlockRegistry();
 
     @Override
     public String getName() {
@@ -34,7 +31,7 @@ public class CommandSchematicaReplace extends CommandSchematicaBase {
     @Override
     public List<String> getTabCompletions(final MinecraftServer server, final ICommandSender sender, final String[] args, final BlockPos pos) {
         if (args.length < 3) {
-            return getListOfStringsMatchingLastWord(args, BLOCK_REGISTRY.getKeys());
+            return getListOfStringsMatchingLastWord(args, Block.REGISTRY.getKeys());
         }
 
         return null;

--- a/src/main/java/com/github/lunatrius/schematica/handler/ConfigurationHandler.java
+++ b/src/main/java/com/github/lunatrius/schematica/handler/ConfigurationHandler.java
@@ -10,8 +10,6 @@ import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.common.config.Property;
 import net.minecraftforge.fml.client.event.ConfigChangedEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
-import net.minecraftforge.fml.common.registry.FMLControlledNamespacedRegistry;
-import net.minecraftforge.fml.common.registry.GameData;
 
 import java.io.File;
 import java.io.IOException;
@@ -23,7 +21,6 @@ import java.util.Set;
 
 public class ConfigurationHandler {
     public static final ConfigurationHandler INSTANCE = new ConfigurationHandler();
-    public static final FMLControlledNamespacedRegistry<Block> BLOCK_REGISTRY = GameData.getBlockRegistry();
 
     public static final String VERSION = "1";
 
@@ -263,7 +260,7 @@ public class ConfigurationHandler {
     private static void populateExtraAirBlocks() {
         extraAirBlockList.clear();
         for (final String name : extraAirBlocks) {
-            final Block block = BLOCK_REGISTRY.getObject(new ResourceLocation(name));
+            final Block block = Block.REGISTRY.getObject(new ResourceLocation(name));
             if (block != Blocks.AIR) {
                 extraAirBlockList.add(block);
             }

--- a/src/main/java/com/github/lunatrius/schematica/handler/client/OverlayHandler.java
+++ b/src/main/java/com/github/lunatrius/schematica/handler/client/OverlayHandler.java
@@ -12,13 +12,10 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
-import net.minecraftforge.fml.common.registry.FMLControlledNamespacedRegistry;
-import net.minecraftforge.fml.common.registry.GameData;
 
 import java.util.ArrayList;
 
 public class OverlayHandler {
-    private static final FMLControlledNamespacedRegistry<Block> BLOCK_REGISTRY = GameData.getBlockRegistry();
     private final Minecraft minecraft = Minecraft.getMinecraft();
 
     @SubscribeEvent
@@ -41,7 +38,7 @@ public class OverlayHandler {
                     final IBlockState blockState = schematic.getBlockState(pos);
 
                     right.add("");
-                    right.add(String.valueOf(BLOCK_REGISTRY.getNameForObject(blockState.getBlock())) + " [§6S§r]");
+                    right.add(String.valueOf(Block.REGISTRY.getNameForObject(blockState.getBlock())) + " [§6S§r]");
 
                     for (final String formattedProperty : BlockStateHelper.getFormattedProperties(blockState)) {
                         right.add(formattedProperty + " [§6S§r]");

--- a/src/main/java/com/github/lunatrius/schematica/handler/client/RenderTickHandler.java
+++ b/src/main/java/com/github/lunatrius/schematica/handler/client/RenderTickHandler.java
@@ -41,7 +41,7 @@ public class RenderTickHandler {
 
         final Vec3d vecPosition = renderViewEntity.getPositionEyes(partialTicks);
         final Vec3d vecLook = renderViewEntity.getLook(partialTicks);
-        final Vec3d vecExtendedLook = vecPosition.addVector(vecLook.xCoord * blockReachDistance, vecLook.yCoord * blockReachDistance, vecLook.zCoord * blockReachDistance);
+        final Vec3d vecExtendedLook = vecPosition.addVector(vecLook.x * blockReachDistance, vecLook.y * blockReachDistance, vecLook.y * blockReachDistance);
 
         renderViewEntity.posX = posX;
         renderViewEntity.posY = posY;

--- a/src/main/java/com/github/lunatrius/schematica/network/message/MessageDownloadBeginAck.java
+++ b/src/main/java/com/github/lunatrius/schematica/network/message/MessageDownloadBeginAck.java
@@ -21,7 +21,7 @@ public class MessageDownloadBeginAck implements IMessage, IMessageHandler<Messag
 
     @Override
     public IMessage onMessage(final MessageDownloadBeginAck message, final MessageContext ctx) {
-        final EntityPlayerMP player = ctx.getServerHandler().playerEntity;
+        final EntityPlayerMP player = ctx.getServerHandler().player;
         final SchematicTransfer transfer = DownloadHandler.INSTANCE.transferMap.get(player);
         if (transfer != null) {
             transfer.setState(SchematicTransfer.State.CHUNK_WAIT);

--- a/src/main/java/com/github/lunatrius/schematica/network/message/MessageDownloadChunk.java
+++ b/src/main/java/com/github/lunatrius/schematica/network/message/MessageDownloadChunk.java
@@ -15,14 +15,11 @@ import net.minecraftforge.fml.common.network.ByteBufUtils;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
 import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
-import net.minecraftforge.fml.common.registry.FMLControlledNamespacedRegistry;
-import net.minecraftforge.fml.common.registry.GameData;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class MessageDownloadChunk implements IMessage, IMessageHandler<MessageDownloadChunk, IMessage> {
-    public static final FMLControlledNamespacedRegistry<Block> BLOCK_REGISTRY = GameData.getBlockRegistry();
 
     public int baseX;
     public int baseY;
@@ -53,7 +50,7 @@ public class MessageDownloadChunk implements IMessage, IMessageHandler<MessageDo
                     pos.set(baseX + x, baseY + y, baseZ + z);
                     final IBlockState blockState = schematic.getBlockState(pos);
                     final Block block = blockState.getBlock();
-                    final int id = BLOCK_REGISTRY.getId(block);
+                    final int id = Block.REGISTRY.getIDForObject(block);
                     this.blocks[x][y][z] = (short) id;
                     this.metadata[x][y][z] = (byte) block.getMetaFromState(blockState);
                     final TileEntity tileEntity = schematic.getTileEntity(pos);
@@ -72,7 +69,7 @@ public class MessageDownloadChunk implements IMessage, IMessageHandler<MessageDo
                 for (int z = 0; z < Constants.SchematicChunk.LENGTH; z++) {
                     final short id = this.blocks[x][y][z];
                     final byte meta = this.metadata[x][y][z];
-                    final Block block = BLOCK_REGISTRY.getObjectById(id);
+                    final Block block = Block.REGISTRY.getObjectById(id);
 
                     pos.set(this.baseX + x, this.baseY + y, this.baseZ + z);
 

--- a/src/main/java/com/github/lunatrius/schematica/network/message/MessageDownloadChunkAck.java
+++ b/src/main/java/com/github/lunatrius/schematica/network/message/MessageDownloadChunkAck.java
@@ -38,7 +38,7 @@ public class MessageDownloadChunkAck implements IMessage, IMessageHandler<Messag
 
     @Override
     public IMessage onMessage(final MessageDownloadChunkAck message, final MessageContext ctx) {
-        final EntityPlayerMP player = ctx.getServerHandler().playerEntity;
+        final EntityPlayerMP player = ctx.getServerHandler().player;
         final SchematicTransfer transfer = DownloadHandler.INSTANCE.transferMap.get(player);
         if (transfer != null) {
             transfer.confirmChunk(message.baseX, message.baseY, message.baseZ);

--- a/src/main/java/com/github/lunatrius/schematica/world/schematic/SchematicAlpha.java
+++ b/src/main/java/com/github/lunatrius/schematica/world/schematic/SchematicAlpha.java
@@ -19,8 +19,6 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.Constants;
-import net.minecraftforge.fml.common.registry.FMLControlledNamespacedRegistry;
-import net.minecraftforge.fml.common.registry.GameData;
 
 import java.util.HashMap;
 import java.util.List;
@@ -28,7 +26,6 @@ import java.util.Map;
 import java.util.Set;
 
 public class SchematicAlpha extends SchematicFormat {
-    private static final FMLControlledNamespacedRegistry<Block> BLOCK_REGISTRY = GameData.getBlockRegistry();
 
     @Override
     public ISchematic readFromNBT(final NBTTagCompound tagCompound) {
@@ -63,7 +60,7 @@ public class SchematicAlpha extends SchematicFormat {
             final NBTTagCompound mapping = tagCompound.getCompoundTag(Names.NBT.MAPPING_SCHEMATICA);
             final Set<String> names = mapping.getKeySet();
             for (final String name : names) {
-                oldToNew.put(mapping.getShort(name), (short) BLOCK_REGISTRY.getId(new ResourceLocation(name)));
+                oldToNew.put(mapping.getShort(name), (short) Block.REGISTRY.getIDForObject(Block.REGISTRY.getObject(new ResourceLocation(name))));
             }
         }
 
@@ -80,13 +77,13 @@ public class SchematicAlpha extends SchematicFormat {
                         blockID = id;
                     }
 
-                    final Block block = BLOCK_REGISTRY.getObjectById(blockID);
+                    final Block block = Block.REGISTRY.getObjectById(blockID);
                     pos.set(x, y, z);
                     try {
                         final IBlockState blockState = block.getStateFromMeta(meta);
                         schematic.setBlockState(pos, blockState);
                     } catch (final Exception e) {
-                        Reference.logger.error("Could not set block state at {} to {} with metadata {}", pos, BLOCK_REGISTRY.getNameForObject(block), meta, e);
+                        Reference.logger.error("Could not set block state at {} to {} with metadata {}", pos, Block.REGISTRY.getNameForObject(block), meta, e);
                     }
                 }
             }
@@ -134,14 +131,14 @@ public class SchematicAlpha extends SchematicFormat {
                     final int index = x + (y * schematic.getLength() + z) * schematic.getWidth();
                     final IBlockState blockState = schematic.getBlockState(pos.set(x, y, z));
                     final Block block = blockState.getBlock();
-                    final int blockId = BLOCK_REGISTRY.getId(block);
+                    final int blockId = Block.REGISTRY.getIDForObject(block);
                     localBlocks[index] = (byte) blockId;
                     localMetadata[index] = (byte) block.getMetaFromState(blockState);
                     if ((extraBlocks[index] = (byte) (blockId >> 8)) > 0) {
                         extra = true;
                     }
 
-                    final String name = String.valueOf(BLOCK_REGISTRY.getNameForObject(block));
+                    final String name = String.valueOf(Block.REGISTRY.getNameForObject(block));
                     if (!mappings.containsKey(name)) {
                         mappings.put(name, (short) blockId);
                     }
@@ -161,9 +158,9 @@ public class SchematicAlpha extends SchematicFormat {
                 if (--count > 0) {
                     final IBlockState blockState = schematic.getBlockState(tePos);
                     final Block block = blockState.getBlock();
-                    Reference.logger.error("Block {}[{}] with TileEntity {} failed to save! Replacing with bedrock...", block, block != null ? BLOCK_REGISTRY.getNameForObject(block) : "?", tileEntity.getClass().getName(), e);
+                    Reference.logger.error("Block {}[{}] with TileEntity {} failed to save! Replacing with bedrock...", block, block != null ? Block.REGISTRY.getNameForObject(block) : "?", tileEntity.getClass().getName(), e);
                 }
-                localBlocks[index] = (byte) BLOCK_REGISTRY.getId(Blocks.BEDROCK);
+                localBlocks[index] = (byte) Block.REGISTRY.getIDForObject(Blocks.BEDROCK);
                 localMetadata[index] = 0;
                 extraBlocks[index] = 0;
             }

--- a/src/main/java/com/github/lunatrius/schematica/world/schematic/SchematicUtil.java
+++ b/src/main/java/com/github/lunatrius/schematica/world/schematic/SchematicUtil.java
@@ -9,8 +9,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompressedStreamTools;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.fml.common.registry.FMLControlledNamespacedRegistry;
-import net.minecraftforge.fml.common.registry.GameData;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -18,8 +16,6 @@ import java.io.IOException;
 
 public final class SchematicUtil {
     public static final ItemStack DEFAULT_ICON = new ItemStack(Blocks.GRASS);
-    public static final FMLControlledNamespacedRegistry<Block> BLOCK_REGISTRY = GameData.getBlockRegistry();
-    public static final FMLControlledNamespacedRegistry<Item> ITEM_REGISTRY = GameData.getItemRegistry();
 
     public static NBTTagCompound readTagCompoundFromFile(final File file) throws IOException {
         try {
@@ -49,12 +45,12 @@ public final class SchematicUtil {
             return DEFAULT_ICON.copy();
         }
 
-        final ItemStack block = new ItemStack(BLOCK_REGISTRY.getObject(rl), 1, damage);
+        final ItemStack block = new ItemStack(Block.REGISTRY.getObject(rl), 1, damage);
         if (!block.isEmpty()) {
             return block;
         }
 
-        final ItemStack item = new ItemStack(ITEM_REGISTRY.getObject(rl), 1, damage);
+        final ItemStack item = new ItemStack(Item.REGISTRY.getObject(rl), 1, damage);
         if (!item.isEmpty()) {
             return item;
         }

--- a/src/main/java/com/github/lunatrius/schematica/world/storage/Schematic.java
+++ b/src/main/java/com/github/lunatrius/schematica/world/storage/Schematic.java
@@ -9,8 +9,6 @@ import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos;
-import net.minecraftforge.fml.common.registry.FMLControlledNamespacedRegistry;
-import net.minecraftforge.fml.common.registry.GameData;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -18,7 +16,6 @@ import java.util.List;
 
 public class Schematic implements ISchematic {
     private static final ItemStack DEFAULT_ICON = new ItemStack(Blocks.GRASS);
-    private static final FMLControlledNamespacedRegistry<Block> BLOCK_REGISTRY = GameData.getBlockRegistry();
 
     private ItemStack icon;
     private final short[][][] blocks;
@@ -48,7 +45,7 @@ public class Schematic implements ISchematic {
         final int x = pos.getX();
         final int y = pos.getY();
         final int z = pos.getZ();
-        final Block block = BLOCK_REGISTRY.getObjectById(this.blocks[x][y][z]);
+        final Block block = Block.REGISTRY.getObjectById(this.blocks[x][y][z]);
 
         return block.getStateFromMeta(this.metadata[x][y][z]);
     }
@@ -60,7 +57,7 @@ public class Schematic implements ISchematic {
         }
 
         final Block block = blockState.getBlock();
-        final int id = BLOCK_REGISTRY.getId(block);
+        final int id = Block.REGISTRY.getIDForObject(block);
         if (id == -1) {
             return false;
         }

--- a/src/main/resources/META-INF/schematica_at.cfg
+++ b/src/main/resources/META-INF/schematica_at.cfg
@@ -1,11 +1,11 @@
 # Schematica
 public net.minecraft.client.renderer.chunk.ChunkRenderDispatcher field_178524_h # queueChunkUploads
-public net.minecraft.client.renderer.chunk.ChunkRenderDispatcher func_178506_a(Lnet/minecraft/client/renderer/VertexBuffer;Lnet/minecraft/client/renderer/vertex/VertexBuffer;)V # uploadVertexBuffer
-public net.minecraft.client.renderer.chunk.ChunkRenderDispatcher func_178510_a(Lnet/minecraft/client/renderer/VertexBuffer;ILnet/minecraft/client/renderer/chunk/RenderChunk;)V # uploadDisplayList
+public net.minecraft.client.renderer.chunk.ChunkRenderDispatcher func_178506_a(Lnet/minecraft/client/renderer/BufferBuilder;Lnet/minecraft/client/renderer/vertex/VertexBuffer;)V # uploadVertexBuffer
+public net.minecraft.client.renderer.chunk.ChunkRenderDispatcher func_178510_a(Lnet/minecraft/client/renderer/BufferBuilder;ILnet/minecraft/client/renderer/chunk/RenderChunk;)V # uploadDisplayList
 
 public net.minecraft.client.renderer.chunk.RenderChunk field_178588_d # world
-public net.minecraft.client.renderer.chunk.RenderChunk func_178573_a(Lnet/minecraft/client/renderer/VertexBuffer;Lnet/minecraft/util/math/BlockPos;)V # preRenderBlocks
-public net.minecraft.client.renderer.chunk.RenderChunk func_178584_a(Lnet/minecraft/util/BlockRenderLayer;FFFLnet/minecraft/client/renderer/VertexBuffer;Lnet/minecraft/client/renderer/chunk/CompiledChunk;)V # postRenderBlocks
+public net.minecraft.client.renderer.chunk.RenderChunk func_178573_a(Lnet/minecraft/client/renderer/BufferBuilder;Lnet/minecraft/util/math/BlockPos;)V # preRenderBlocks
+public net.minecraft.client.renderer.chunk.RenderChunk func_178584_a(Lnet/minecraft/util/BlockRenderLayer;FFFLnet/minecraft/client/renderer/BufferBuilder;Lnet/minecraft/client/renderer/chunk/CompiledChunk;)V # postRenderBlocks
 
 public net.minecraft.client.renderer.ViewFrustum func_178161_a(Lnet/minecraft/util/math/BlockPos;)Lnet/minecraft/client/renderer/chunk/RenderChunk; # getRenderChunk
 


### PR DESCRIPTION
This build is dependent on the Pull Request that I did for LunatriusCore (1.1.3: https://github.com/Lunatrius/LunatriusCore/pull/20).

- Changed from VertexBuffer to BufferBuilder
- Some method mapping and field mapping changes in Forge
- Changed from Objects to MoreObjects due to the depricated function firstNonNull in com.google.common.base
- A couple Access Transformers changed in MCP
- Added some missing 1.12 override methods in GuiFactory and Predicate
- Parameter added to drawSlot in 1.12

Only the necessary stuff for using it in 1.12.