### PR TITLE
Miscellaneous tweaks (don't pause when saving; indicate looked-at block in schematics)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 /.classpath
 /.project
 /bin
+Schematica_Client.launch
+Schematica_Server.launch
 
 ## intellij
 /out

--- a/src/main/java/com/github/lunatrius/schematica/client/gui/control/GuiSchematicControl.java
+++ b/src/main/java/com/github/lunatrius/schematica/client/gui/control/GuiSchematicControl.java
@@ -235,7 +235,7 @@ public class GuiSchematicControl extends GuiScreenBase {
     }
 
     @Override
-    public void drawScreen(final int par1, final int par2, final float par3) {
+    public void drawScreen(final int mouseX, final int mouseY, final float partialTicks) {
         // drawDefaultBackground();
 
         drawCenteredString(this.fontRendererObj, this.strMoveSchematic, this.centerX, this.centerY - 45, 0xFFFFFF);
@@ -248,6 +248,6 @@ public class GuiSchematicControl extends GuiScreenBase {
         drawString(this.fontRendererObj, this.strY, this.centerX - 65, this.centerY + 1, 0xFFFFFF);
         drawString(this.fontRendererObj, this.strZ, this.centerX - 65, this.centerY + 26, 0xFFFFFF);
 
-        super.drawScreen(par1, par2, par3);
+        super.drawScreen(mouseX, mouseY, partialTicks);
     }
 }

--- a/src/main/java/com/github/lunatrius/schematica/client/gui/control/GuiSchematicMaterialsSlot.java
+++ b/src/main/java/com/github/lunatrius/schematica/client/gui/control/GuiSchematicMaterialsSlot.java
@@ -20,9 +20,9 @@ class GuiSchematicMaterialsSlot extends GuiSlot {
 
     protected int selectedIndex = -1;
 
-    public GuiSchematicMaterialsSlot(final GuiSchematicMaterials par1) {
-        super(Minecraft.getMinecraft(), par1.width, par1.height, 16, par1.height - 34, 24);
-        this.guiSchematicMaterials = par1;
+    public GuiSchematicMaterialsSlot(final GuiSchematicMaterials parent) {
+        super(Minecraft.getMinecraft(), parent.width, parent.height, 16, parent.height - 34, 24);
+        this.guiSchematicMaterials = parent;
         this.selectedIndex = -1;
     }
 

--- a/src/main/java/com/github/lunatrius/schematica/client/gui/save/GuiSchematicSave.java
+++ b/src/main/java/com/github/lunatrius/schematica/client/gui/save/GuiSchematicSave.java
@@ -197,4 +197,10 @@ public class GuiSchematicSave extends GuiScreenBase {
 
         super.drawScreen(mouseX, mouseY, partialTicks);
     }
+
+    // We don't want to pause the game when saving schematics in single-player
+    @Override
+    public boolean doesGuiPauseGame() {
+        return false;
+    }
 }

--- a/src/main/java/com/github/lunatrius/schematica/client/gui/save/GuiSchematicSave.java
+++ b/src/main/java/com/github/lunatrius/schematica/client/gui/save/GuiSchematicSave.java
@@ -172,7 +172,7 @@ public class GuiSchematicSave extends GuiScreenBase {
     }
 
     @Override
-    public void drawScreen(final int par1, final int par2, final float par3) {
+    public void drawScreen(final int mouseX, final int mouseY, final float partialTicks) {
         // drawDefaultBackground();
 
         drawString(this.fontRendererObj, this.strSaveSelection, this.width - 205, this.height - 45, 0xFFFFFF);
@@ -195,6 +195,6 @@ public class GuiSchematicSave extends GuiScreenBase {
         drawString(this.fontRendererObj, this.strZ, this.centerX + 15, this.centerY + 26, 0xFFFFFF);
         drawString(this.fontRendererObj, Integer.toString(ClientProxy.pointB.z), this.centerX + 135, this.centerY + 26, 0xFFFFFF);
 
-        super.drawScreen(par1, par2, par3);
+        super.drawScreen(mouseX, mouseY, partialTicks);
     }
 }

--- a/src/main/java/com/github/lunatrius/schematica/handler/client/OverlayHandler.java
+++ b/src/main/java/com/github/lunatrius/schematica/handler/client/OverlayHandler.java
@@ -50,6 +50,16 @@ public class OverlayHandler {
                     for (final String formattedProperty : BlockStateHelper.getFormattedProperties(blockState)) {
                         right.add(formattedProperty + SCHEMATICA_SUFFIX);
                     }
+
+                    final BlockPos offsetPos = pos.add(schematic.position);
+                    String lookMessage = String.format("Looking at: %d %d %d (%d %d %d)", pos.getX(), pos.getY(), pos.getZ(), offsetPos.getX(), offsetPos.getY(), offsetPos.getZ());
+                    if (this.minecraft.objectMouseOver != null && this.minecraft.objectMouseOver.typeOfHit == RayTraceResult.Type.BLOCK) {
+                        final BlockPos origPos = this.minecraft.objectMouseOver.getBlockPos();
+                        if (offsetPos.equals(origPos)) {
+                            lookMessage += " (matches)";
+                        }
+                    }
+                    left.add(SCHEMATICA_PREFIX + lookMessage);
                 }
             }
         }

--- a/src/main/java/com/github/lunatrius/schematica/handler/client/OverlayHandler.java
+++ b/src/main/java/com/github/lunatrius/schematica/handler/client/OverlayHandler.java
@@ -10,6 +10,7 @@ import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
+import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.registry.FMLControlledNamespacedRegistry;
@@ -21,6 +22,9 @@ public class OverlayHandler {
     private static final FMLControlledNamespacedRegistry<Block> BLOCK_REGISTRY = GameData.getBlockRegistry();
     private final Minecraft minecraft = Minecraft.getMinecraft();
 
+    private static final String SCHEMATICA_PREFIX= "[" + TextFormatting.GOLD + "Schematica" + TextFormatting.RESET + "] ";
+    private static final String SCHEMATICA_SUFFIX = " [" + TextFormatting.GOLD + "S" + TextFormatting.RESET + "]";
+
     @SubscribeEvent
     public void onText(final RenderGameOverlayEvent.Text event) {
         if (this.minecraft.gameSettings.showDebugInfo && ConfigurationHandler.showDebugInfo) {
@@ -30,10 +34,10 @@ public class OverlayHandler {
                 final ArrayList<String> right = event.getRight();
 
                 left.add("");
-                left.add("[§6Schematica§r] " + schematic.getDebugDimensions());
-                // event.left.add("[§6Schematica§r] " + RenderSchematic.INSTANCE.getDebugInfoEntities());
-                left.add("[§6Schematica§r] " + RenderSchematic.INSTANCE.getDebugInfoTileEntities());
-                left.add("[§6Schematica§r] " + RenderSchematic.INSTANCE.getDebugInfoRenders());
+                left.add(SCHEMATICA_PREFIX+ schematic.getDebugDimensions());
+                // left.add(SCHEMATICA_PREFIX + RenderSchematic.INSTANCE.getDebugInfoEntities());
+                left.add(SCHEMATICA_PREFIX + RenderSchematic.INSTANCE.getDebugInfoTileEntities());
+                left.add(SCHEMATICA_PREFIX + RenderSchematic.INSTANCE.getDebugInfoRenders());
 
                 final RayTraceResult rtr = ClientProxy.objectMouseOver;
                 if (rtr != null && rtr.typeOfHit == RayTraceResult.Type.BLOCK) {
@@ -41,10 +45,10 @@ public class OverlayHandler {
                     final IBlockState blockState = schematic.getBlockState(pos);
 
                     right.add("");
-                    right.add(String.valueOf(BLOCK_REGISTRY.getNameForObject(blockState.getBlock())) + " [§6S§r]");
+                    right.add(String.valueOf(BLOCK_REGISTRY.getNameForObject(blockState.getBlock())) + SCHEMATICA_SUFFIX);
 
                     for (final String formattedProperty : BlockStateHelper.getFormattedProperties(blockState)) {
-                        right.add(formattedProperty + " [§6S§r]");
+                        right.add(formattedProperty + SCHEMATICA_SUFFIX);
                     }
                 }
             }


### PR DESCRIPTION
This is the first of several PRs I plan to make.  There's several different changes (which I have kept in separate commits, since each one could be cherry-picked on its own), each explained with more detail in its commit message.

* 185ab86 Update .gitignore:  
    Ignores some files generated by FG's `eclipse` task
* 035f316 Remove bare section signs:  
    Cleanup in the debug overlay.
* cda035b Indicate the position in the schematic that is being looked at:  
    Adds some more useful information to the debug overlay, which can be useful ingame.
* 0424ea1 Clean up unnamed method parameters:  
    Cleanup of method parameters for GUIs, updating it to use MCP-esque names rather than `par1`.  Doesn't touch GuiSlot-related names.
* 526982f Don't pause the game in singleplayer on the save schematics GUI:  
    Since schematics are only saved when the game isn't paused, it makes sense not to pause the game while in the save schematic GUI.