### PR TITLE
Add support for saving/loading in the structure block format

### DIFF
--- a/src/api/java/com/github/lunatrius/schematica/api/ISchematic.java
+++ b/src/api/java/com/github/lunatrius/schematica/api/ISchematic.java
@@ -8,6 +8,8 @@ import net.minecraft.util.math.BlockPos;
 
 import java.util.List;
 
+import javax.annotation.Nonnull;
+
 public interface ISchematic {
     /**
      * Gets a block state at a given location within the schematic. Requesting a block state outside of those bounds
@@ -114,4 +116,19 @@ public interface ISchematic {
      * @return the schematic height
      */
     int getHeight();
+
+    /**
+     * Gets the author of the schematic, or an empty String if unknown.
+     *
+     * @return The author of the schematic.
+     */
+    @Nonnull
+    String getAuthor();
+
+    /**
+     * Sets the author of the schematic.
+     *
+     * @param author The new author of the schematic.
+     */
+    void setAuthor(@Nonnull String author);
 }

--- a/src/main/java/com/github/lunatrius/schematica/client/gui/load/GuiSchematicLoadSlot.java
+++ b/src/main/java/com/github/lunatrius/schematica/client/gui/load/GuiSchematicLoadSlot.java
@@ -4,6 +4,7 @@ import com.github.lunatrius.core.client.gui.GuiHelper;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiSlot;
 import net.minecraft.client.renderer.Tessellator;
+import org.apache.commons.io.FilenameUtils;
 
 public class GuiSchematicLoadSlot extends GuiSlot {
     private final Minecraft minecraft = Minecraft.getMinecraft();
@@ -66,7 +67,7 @@ public class GuiSchematicLoadSlot extends GuiSlot {
         if (schematic.isDirectory()) {
             schematicName += "/";
         } else {
-            schematicName = schematicName.replaceAll("(?i)\\.schematic$", "");
+            schematicName = FilenameUtils.getBaseName(schematicName);
         }
 
         GuiHelper.drawItemStackWithSlot(this.minecraft.renderEngine, schematic.getItemStack(), x, y);

--- a/src/main/java/com/github/lunatrius/schematica/client/gui/save/GuiSchematicSave.java
+++ b/src/main/java/com/github/lunatrius/schematica/client/gui/save/GuiSchematicSave.java
@@ -16,6 +16,7 @@ import net.minecraft.util.math.BlockPos;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Iterator;
 
 public class GuiSchematicSave extends GuiScreenBase {
     private int centerX = 0;
@@ -34,10 +35,20 @@ public class GuiSchematicSave extends GuiScreenBase {
     private GuiNumericField numericBZ = null;
 
     private GuiButton btnEnable = null;
+    private GuiButton btnFormat = null;
     private GuiButton btnSave = null;
     private GuiTextField tfFilename = null;
 
     private String filename = "";
+
+    /** The currently selected format */
+    private String format;
+    /**
+     * An iterator that gets new formats from {@link SchematicFormat#FORMATS}.
+     *
+     * Is reset after it no longer has new elements.
+     */
+    private Iterator<String> formatIterator = null;
 
     private final String strSaveSelection = I18n.format(Names.Gui.Save.SAVE_SELECTION);
     private final String strX = I18n.format(Names.Gui.X);
@@ -48,10 +59,12 @@ public class GuiSchematicSave extends GuiScreenBase {
 
     public GuiSchematicSave(final GuiScreen guiScreen) {
         super(guiScreen);
+        this.format = nextFormat();
     }
 
     @Override
     public void initGui() {
+        SchematicFormat.FORMAT_DEFAULT = Names.NBT.FORMAT_ALPHA;
         this.centerX = this.width / 2;
         this.centerY = this.height / 2;
 
@@ -83,15 +96,19 @@ public class GuiSchematicSave extends GuiScreenBase {
         this.numericBZ = new GuiNumericField(this.fontRenderer, id++, this.centerX + 30, this.centerY + 20);
         this.buttonList.add(this.numericBZ);
 
-        this.btnEnable = new GuiButton(id++, this.width - 210, this.height - 30, 50, 20, ClientProxy.isRenderingGuide && Schematica.proxy.isSaveEnabled ? this.strOn : this.strOff);
+        this.btnEnable = new GuiButton(id++, this.width - 210, this.height - 55, 50, 20, ClientProxy.isRenderingGuide && Schematica.proxy.isSaveEnabled ? this.strOn : this.strOff);
         this.buttonList.add(this.btnEnable);
 
-        this.tfFilename = new GuiTextField(id++, this.fontRenderer, this.width - 155, this.height - 29, 100, 18);
+        this.tfFilename = new GuiTextField(id++, this.fontRenderer, this.width - 209, this.height - 29, 153, 18);
         this.textFields.add(this.tfFilename);
 
         this.btnSave = new GuiButton(id++, this.width - 50, this.height - 30, 40, 20, I18n.format(Names.Gui.Save.SAVE));
         this.btnSave.enabled = ClientProxy.isRenderingGuide && Schematica.proxy.isSaveEnabled || ClientProxy.schematic != null;
         this.buttonList.add(this.btnSave);
+
+        this.btnFormat = new GuiButton(id++, this.width - 155, this.height - 55, 145, 20, I18n.format(Names.Gui.Save.FORMAT, I18n.format(SchematicFormat.getFormatName(this.format))));
+        this.btnFormat.enabled = ClientProxy.isRenderingGuide && Schematica.proxy.isSaveEnabled || ClientProxy.schematic != null;
+        this.buttonList.add(this.btnFormat);
 
         this.tfFilename.setMaxStringLength(1024);
         this.tfFilename.setText(this.filename);
@@ -151,15 +168,19 @@ public class GuiSchematicSave extends GuiScreenBase {
                 ClientProxy.isRenderingGuide = !ClientProxy.isRenderingGuide && Schematica.proxy.isSaveEnabled;
                 this.btnEnable.displayString = ClientProxy.isRenderingGuide ? this.strOn : this.strOff;
                 this.btnSave.enabled = ClientProxy.isRenderingGuide || ClientProxy.schematic != null;
+                this.btnFormat.enabled = ClientProxy.isRenderingGuide || ClientProxy.schematic != null;
+            } else if (guiButton.id == this.btnFormat.id) {
+                this.format = nextFormat();
+                this.btnFormat.displayString = I18n.format(Names.Gui.Save.FORMAT, I18n.format(SchematicFormat.getFormatName(this.format)));
             } else if (guiButton.id == this.btnSave.id) {
-                final String path = this.tfFilename.getText() + ".schematic";
+                final String path = this.tfFilename.getText() + SchematicFormat.getExtension(this.format);
                 if (ClientProxy.isRenderingGuide) {
-                    if (Schematica.proxy.saveSchematic(this.mc.player, ConfigurationHandler.schematicDirectory, path, this.mc.world, ClientProxy.pointMin, ClientProxy.pointMax)) {
+                    if (Schematica.proxy.saveSchematic(this.mc.player, ConfigurationHandler.schematicDirectory, path, this.mc.world, this.format, ClientProxy.pointMin, ClientProxy.pointMax)) {
                         this.filename = "";
                         this.tfFilename.setText(this.filename);
                     }
                 } else {
-                    SchematicFormat.writeToFileAndNotify(new File(ConfigurationHandler.schematicDirectory, path), ClientProxy.schematic.getSchematic(), this.mc.player);
+                    SchematicFormat.writeToFileAndNotify(new File(ConfigurationHandler.schematicDirectory, path), this.format, ClientProxy.schematic.getSchematic(), this.mc.player);
                 }
             }
         }
@@ -175,7 +196,7 @@ public class GuiSchematicSave extends GuiScreenBase {
     public void drawScreen(final int mouseX, final int mouseY, final float partialTicks) {
         // drawDefaultBackground();
 
-        drawString(this.fontRenderer, this.strSaveSelection, this.width - 205, this.height - 45, 0xFFFFFF);
+        drawString(this.fontRenderer, this.strSaveSelection, this.width - 205, this.height - 70, 0xFFFFFF);
 
         drawString(this.fontRenderer, this.strX, this.centerX - 145, this.centerY - 24, 0xFFFFFF);
         drawString(this.fontRenderer, Integer.toString(ClientProxy.pointA.x), this.centerX - 25, this.centerY - 24, 0xFFFFFF);
@@ -196,5 +217,30 @@ public class GuiSchematicSave extends GuiScreenBase {
         drawString(this.fontRenderer, Integer.toString(ClientProxy.pointB.z), this.centerX + 135, this.centerY + 26, 0xFFFFFF);
 
         super.drawScreen(mouseX, mouseY, partialTicks);
+    }
+
+    /**
+     * Advances the format iterator, reseting it as needed.
+     * If the format iterator is null, initializes it to the default format.
+     *
+     * @return The next format value
+     */
+    private String nextFormat() {
+        if (this.formatIterator == null) {
+            // First time; prime it so that it just returned the default value
+            assert SchematicFormat.FORMATS.size() > 0 : "No formats are defined!";
+            assert SchematicFormat.FORMATS.containsKey(SchematicFormat.FORMAT_DEFAULT) : "The default format does not exist!";
+
+            this.formatIterator = SchematicFormat.FORMATS.keySet().iterator();
+            while (!this.formatIterator.next().equals(SchematicFormat.FORMAT_DEFAULT)) {
+                continue;
+            }
+            return SchematicFormat.FORMAT_DEFAULT;
+        }
+
+        if (!this.formatIterator.hasNext()) {
+            this.formatIterator = SchematicFormat.FORMATS.keySet().iterator();
+        }
+        return this.formatIterator.next();
     }
 }

--- a/src/main/java/com/github/lunatrius/schematica/client/gui/save/GuiSchematicSave.java
+++ b/src/main/java/com/github/lunatrius/schematica/client/gui/save/GuiSchematicSave.java
@@ -64,7 +64,6 @@ public class GuiSchematicSave extends GuiScreenBase {
 
     @Override
     public void initGui() {
-        SchematicFormat.FORMAT_DEFAULT = Names.NBT.FORMAT_ALPHA;
         this.centerX = this.width / 2;
         this.centerY = this.height / 2;
 

--- a/src/main/java/com/github/lunatrius/schematica/client/util/FlipHelper.java
+++ b/src/main/java/com/github/lunatrius/schematica/client/util/FlipHelper.java
@@ -50,7 +50,7 @@ public class FlipHelper {
 
     public Schematic flip(final ISchematic schematic, final EnumFacing axis, final boolean forced) throws FlipException {
         final Vec3i dimensionsFlipped = new Vec3i(schematic.getWidth(), schematic.getHeight(), schematic.getLength());
-        final Schematic schematicFlipped = new Schematic(schematic.getIcon(), dimensionsFlipped.getX(), dimensionsFlipped.getY(), dimensionsFlipped.getZ());
+        final Schematic schematicFlipped = new Schematic(schematic.getIcon(), dimensionsFlipped.getX(), dimensionsFlipped.getY(), dimensionsFlipped.getZ(), schematic.getAuthor());
         final MBlockPos tmp = new MBlockPos();
 
         for (final MBlockPos pos : BlockPosHelper.getAllInBox(0, 0, 0, schematic.getWidth() - 1, schematic.getHeight() - 1, schematic.getLength() - 1)) {

--- a/src/main/java/com/github/lunatrius/schematica/client/util/RotationHelper.java
+++ b/src/main/java/com/github/lunatrius/schematica/client/util/RotationHelper.java
@@ -87,7 +87,7 @@ public class RotationHelper {
 
     public Schematic rotate(final ISchematic schematic, final EnumFacing axis, final boolean forced) throws RotationException {
         final Vec3i dimensionsRotated = rotateDimensions(axis, schematic.getWidth(), schematic.getHeight(), schematic.getLength());
-        final Schematic schematicRotated = new Schematic(schematic.getIcon(), dimensionsRotated.getX(), dimensionsRotated.getY(), dimensionsRotated.getZ());
+        final Schematic schematicRotated = new Schematic(schematic.getIcon(), dimensionsRotated.getX(), dimensionsRotated.getY(), dimensionsRotated.getZ(), schematic.getAuthor());
         final MBlockPos tmp = new MBlockPos();
 
         for (final MBlockPos pos : BlockPosHelper.getAllInBox(0, 0, 0, schematic.getWidth() - 1, schematic.getHeight() - 1, schematic.getLength() - 1)) {

--- a/src/main/java/com/github/lunatrius/schematica/command/CommandSchematicaDownload.java
+++ b/src/main/java/com/github/lunatrius/schematica/command/CommandSchematicaDownload.java
@@ -17,7 +17,6 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.TextComponentTranslation;
-import org.apache.commons.io.FilenameUtils;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -49,7 +48,7 @@ public class CommandSchematicaDownload extends CommandSchematicaBase {
             final List<String> filenames = new ArrayList<String>();
 
             for (final File file : files) {
-                filenames.add(FilenameUtils.removeExtension(file.getName()));
+                filenames.add(file.getName());
             }
 
             return getListOfStringsMatchingLastWord(args, filenames);
@@ -68,7 +67,7 @@ public class CommandSchematicaDownload extends CommandSchematicaBase {
             throw new CommandException(Names.Command.Download.Message.PLAYERS_ONLY);
         }
 
-        final String filename = args[0] + ".schematic";
+        final String filename = String.join(" ", args);
         final EntityPlayerMP player = (EntityPlayerMP) sender;
         final File directory = Schematica.proxy.getPlayerSchematicDirectory(player, true);
         if (!FileUtils.contains(directory, filename)) {

--- a/src/main/java/com/github/lunatrius/schematica/command/CommandSchematicaList.java
+++ b/src/main/java/com/github/lunatrius/schematica/command/CommandSchematicaList.java
@@ -74,9 +74,9 @@ public class CommandSchematicaList extends CommandSchematicaBase {
         final File[] files = schematicDirectory.listFiles(FILE_FILTER_SCHEMATIC);
         for (final File path : files) {
             if (currentFile >= pageStart && currentFile < pageEnd) {
-                final String fileName = FilenameUtils.removeExtension(path.getName());
+                final String fileName = path.getName();
 
-                final ITextComponent chatComponent = new TextComponentString(String.format("%2d (%s): %s [", currentFile + 1, FileUtils.humanReadableByteCount(path.length()), fileName));
+                final ITextComponent chatComponent = new TextComponentString(String.format("%2d (%s): %s [", currentFile + 1, FileUtils.humanReadableByteCount(path.length()), FilenameUtils.removeExtension(fileName)));
 
                 final String removeCommand = String.format("/%s %s", Names.Command.Remove.NAME, fileName);
                 final ITextComponent removeLink = withStyle(new TextComponentTranslation(Names.Command.List.Message.REMOVE), TextFormatting.RED, removeCommand);

--- a/src/main/java/com/github/lunatrius/schematica/command/CommandSchematicaRemove.java
+++ b/src/main/java/com/github/lunatrius/schematica/command/CommandSchematicaRemove.java
@@ -6,7 +6,6 @@ import com.github.lunatrius.schematica.reference.Names;
 import com.github.lunatrius.schematica.reference.Reference;
 import com.google.common.base.Charsets;
 import com.google.common.hash.Hashing;
-import joptsimple.internal.Strings;
 import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.command.WrongUsageException;
@@ -44,7 +43,7 @@ public class CommandSchematicaRemove extends CommandSchematicaBase {
         final EntityPlayer player = (EntityPlayer) sender;
 
         boolean delete = false;
-        String name = Strings.join(args, " ");
+        String name = String.join(" ", args);
 
         if (args.length > 1) {
             //check if the last parameter is a hash, which constitutes a confirmation.
@@ -53,7 +52,7 @@ public class CommandSchematicaRemove extends CommandSchematicaBase {
                 //We probably have a match.
                 final String[] a = Arrays.copyOfRange(args, 0, args.length - 1);
                 //The name then should be everything except the last element
-                name = Strings.join(a, " ");
+                name = String.join(" ", a);
 
                 final String hash = Hashing.md5().hashString(name, Charsets.UTF_8).toString();
 
@@ -63,11 +62,10 @@ public class CommandSchematicaRemove extends CommandSchematicaBase {
             }
         }
 
-        final String filename = String.format("%s.schematic", name);
         final File schematicDirectory = Schematica.proxy.getPlayerSchematicDirectory(player, true);
-        final File file = new File(schematicDirectory, filename);
+        final File file = new File(schematicDirectory, name);
         if (!FileUtils.contains(schematicDirectory, file)) {
-            Reference.logger.error("{} has tried to download the file {}", player.getName(), filename);
+            Reference.logger.error("{} has tried to download the file {}", player.getName(), name);
             throw new CommandException(Names.Command.Remove.Message.SCHEMATIC_NOT_FOUND);
         }
 

--- a/src/main/java/com/github/lunatrius/schematica/command/CommandSchematicaSave.java
+++ b/src/main/java/com/github/lunatrius/schematica/command/CommandSchematicaSave.java
@@ -5,6 +5,7 @@ import com.github.lunatrius.schematica.Schematica;
 import com.github.lunatrius.schematica.reference.Constants;
 import com.github.lunatrius.schematica.reference.Names;
 import com.github.lunatrius.schematica.reference.Reference;
+import com.github.lunatrius.schematica.world.schematic.SchematicFormat;
 import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.command.NumberInvalidException;
@@ -46,13 +47,22 @@ public class CommandSchematicaSave extends CommandSchematicaBase {
         final MBlockPos to = new MBlockPos();
         final String filename;
         final String name;
+        final String format;
 
         try {
             from.set(parseCoord(args[0]), parseCoord(args[1]), parseCoord(args[2]));
             to.set(parseCoord(args[3]), parseCoord(args[4]), parseCoord(args[5]));
 
             name = args[6];
-            filename = String.format("%s.schematic", name);
+            if (args.length >= 8) {
+                format = args[7];
+                if (!SchematicFormat.FORMATS.containsKey(format)) {
+                    throw new CommandException(Names.Command.Save.Message.UNKNOWN_FORMAT, format);
+                }
+            } else {
+                format = null;
+            }
+            filename = name + SchematicFormat.getExtension(format);
         } catch (final NumberFormatException exception) {
             throw new WrongUsageException(getUsage(sender));
         }
@@ -73,7 +83,7 @@ public class CommandSchematicaSave extends CommandSchematicaBase {
         }
 
         try {
-            Schematica.proxy.saveSchematic(player, schematicDirectory, filename, player.getEntityWorld(), null /*TODO*/, from, to);
+            Schematica.proxy.saveSchematic(player, schematicDirectory, filename, player.getEntityWorld(), format, from, to);
             sender.sendMessage(new TextComponentTranslation(Names.Command.Save.Message.SAVE_SUCCESSFUL, name));
         } catch (final Exception e) {
             throw new CommandException(Names.Command.Save.Message.SAVE_FAILED, name);

--- a/src/main/java/com/github/lunatrius/schematica/command/CommandSchematicaSave.java
+++ b/src/main/java/com/github/lunatrius/schematica/command/CommandSchematicaSave.java
@@ -73,7 +73,7 @@ public class CommandSchematicaSave extends CommandSchematicaBase {
         }
 
         try {
-            Schematica.proxy.saveSchematic(player, schematicDirectory, filename, player.getEntityWorld(), from, to);
+            Schematica.proxy.saveSchematic(player, schematicDirectory, filename, player.getEntityWorld(), null /*TODO*/, from, to);
             sender.sendMessage(new TextComponentTranslation(Names.Command.Save.Message.SAVE_SUCCESSFUL, name));
         } catch (final Exception e) {
             throw new CommandException(Names.Command.Save.Message.SAVE_FAILED, name);

--- a/src/main/java/com/github/lunatrius/schematica/handler/QueueTickHandler.java
+++ b/src/main/java/com/github/lunatrius/schematica/handler/QueueTickHandler.java
@@ -68,7 +68,7 @@ public class QueueTickHandler {
         if (container.hasNext()) {
             this.queue.offer(container);
         } else {
-            SchematicFormat.writeToFileAndNotify(container.file, container.schematic, container.player);
+            SchematicFormat.writeToFileAndNotify(container.file, container.format, container.schematic, container.player);
         }
     }
 

--- a/src/main/java/com/github/lunatrius/schematica/network/message/MessageDownloadEnd.java
+++ b/src/main/java/com/github/lunatrius/schematica/network/message/MessageDownloadEnd.java
@@ -37,7 +37,7 @@ public class MessageDownloadEnd implements IMessage, IMessageHandler<MessageDown
     @Override
     public IMessage onMessage(final MessageDownloadEnd message, final MessageContext ctx) {
         final File directory = Schematica.proxy.getPlayerSchematicDirectory(null, true);
-        final boolean success = SchematicFormat.writeToFile(directory, message.name, DownloadHandler.INSTANCE.schematic);
+        final boolean success = SchematicFormat.writeToFile(directory, message.name, null, DownloadHandler.INSTANCE.schematic);
 
         if (success) {
             Minecraft.getMinecraft().player.sendMessage(new TextComponentTranslation(Names.Command.Download.Message.DOWNLOAD_SUCCEEDED, message.name));

--- a/src/main/java/com/github/lunatrius/schematica/proxy/CommonProxy.java
+++ b/src/main/java/com/github/lunatrius/schematica/proxy/CommonProxy.java
@@ -35,6 +35,8 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 public abstract class CommonProxy {
     public boolean isSaveEnabled = true;
     public boolean isLoadEnabled = true;
@@ -160,7 +162,7 @@ public abstract class CommonProxy {
         }
     }
 
-    public boolean saveSchematic(final EntityPlayer player, final File directory, String filename, final World world, final BlockPos from, final BlockPos to) {
+    public boolean saveSchematic(final EntityPlayer player, final File directory, String filename, final World world, @Nullable final String format, final BlockPos from, final BlockPos to) {
         try {
             String iconName = "";
 
@@ -186,7 +188,7 @@ public abstract class CommonProxy {
             final short length = (short) (Math.abs(maxZ - minZ) + 1);
 
             final ISchematic schematic = new Schematic(SchematicUtil.getIconFromName(iconName), width, height, length, player.getName());
-            final SchematicContainer container = new SchematicContainer(schematic, player, world, new File(directory, filename), minX, maxX, minY, maxY, minZ, maxZ);
+            final SchematicContainer container = new SchematicContainer(schematic, player, world, new File(directory, filename), format, minX, maxX, minY, maxY, minZ, maxZ);
             QueueTickHandler.INSTANCE.queueSchematic(container);
 
             return true;

--- a/src/main/java/com/github/lunatrius/schematica/proxy/CommonProxy.java
+++ b/src/main/java/com/github/lunatrius/schematica/proxy/CommonProxy.java
@@ -185,7 +185,7 @@ public abstract class CommonProxy {
             final short height = (short) (Math.abs(maxY - minY) + 1);
             final short length = (short) (Math.abs(maxZ - minZ) + 1);
 
-            final ISchematic schematic = new Schematic(SchematicUtil.getIconFromName(iconName), width, height, length);
+            final ISchematic schematic = new Schematic(SchematicUtil.getIconFromName(iconName), width, height, length, player.getName());
             final SchematicContainer container = new SchematicContainer(schematic, player, world, new File(directory, filename), minX, maxX, minY, maxY, minZ, maxZ);
             QueueTickHandler.INSTANCE.queueSchematic(container);
 

--- a/src/main/java/com/github/lunatrius/schematica/reference/Names.java
+++ b/src/main/java/com/github/lunatrius/schematica/reference/Names.java
@@ -77,6 +77,7 @@ public final class Names {
                 public static final String SAVE_FAILED = "schematica.command.save.saveFailed";
                 public static final String QUOTA_EXCEEDED = "schematica.command.save.quotaExceeded";
                 public static final String PLAYER_SCHEMATIC_DIR_UNAVAILABLE = "schematica.command.save.playerSchematicDirUnavailable";
+                public static final String UNKNOWN_FORMAT = "schematica.command.save.unknownFormat";
             }
 
             public static final String NAME = "schematicaSave";
@@ -233,6 +234,7 @@ public final class Names {
         public static final String CLASSIC = "schematica.format.classic";
         public static final String ALPHA = "schematica.format.alpha";
         public static final String STRUCTURE = "schematica.format.structure";
+        public static final String INVALID = "schematica.format.invalid";
     }
 
     public static final class Extensions {

--- a/src/main/java/com/github/lunatrius/schematica/reference/Names.java
+++ b/src/main/java/com/github/lunatrius/schematica/reference/Names.java
@@ -153,6 +153,7 @@ public final class Names {
             public static final String POINT_BLUE = "schematica.gui.point.blue";
             public static final String SAVE = "schematica.gui.save";
             public static final String SAVE_SELECTION = "schematica.gui.saveselection";
+            public static final String FORMAT = "schematica.gui.format";
         }
 
         public static final class Control {
@@ -226,5 +227,16 @@ public final class Names {
         public static final String TILE_ENTITIES = "TileEntities";
         public static final String ENTITIES = "Entities";
         public static final String EXTENDED_METADATA = "ExtendedMetadata";
+    }
+
+    public static final class Formats {
+        public static final String CLASSIC = "schematica.format.classic";
+        public static final String ALPHA = "schematica.format.alpha";
+        public static final String STRUCTURE = "schematica.format.structure";
+    }
+
+    public static final class Extensions {
+        public static final String SCHEMATIC = ".schematic";
+        public static final String STRUCTURE = ".nbt";
     }
 }

--- a/src/main/java/com/github/lunatrius/schematica/reference/Names.java
+++ b/src/main/java/com/github/lunatrius/schematica/reference/Names.java
@@ -212,6 +212,7 @@ public final class Names {
         public static final String MATERIALS = "Materials";
         public static final String FORMAT_CLASSIC = "Classic";
         public static final String FORMAT_ALPHA = "Alpha";
+        public static final String FORMAT_STRUCTURE = "Structure";
 
         public static final String ICON = "Icon";
         public static final String BLOCKS = "Blocks";

--- a/src/main/java/com/github/lunatrius/schematica/util/FileFilterSchematic.java
+++ b/src/main/java/com/github/lunatrius/schematica/util/FileFilterSchematic.java
@@ -1,5 +1,8 @@
 package com.github.lunatrius.schematica.util;
 
+import com.github.lunatrius.schematica.world.schematic.SchematicFormat;
+import org.apache.commons.io.FilenameUtils;
+
 import java.io.File;
 import java.io.FileFilter;
 import java.util.Locale;
@@ -17,6 +20,12 @@ public class FileFilterSchematic implements FileFilter {
             return file.isDirectory();
         }
 
-        return file.getName().toLowerCase(Locale.ENGLISH).endsWith(".schematic");
+        String extension = "." + FilenameUtils.getExtension(file.getName().toLowerCase(Locale.ROOT));
+        for (SchematicFormat format : SchematicFormat.FORMATS.values()) {
+            if (format.getExtension().equals(extension)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/com/github/lunatrius/schematica/world/chunk/SchematicContainer.java
+++ b/src/main/java/com/github/lunatrius/schematica/world/chunk/SchematicContainer.java
@@ -8,11 +8,15 @@ import net.minecraft.world.World;
 
 import java.io.File;
 
+import javax.annotation.Nullable;
+
 public class SchematicContainer {
     public final ISchematic schematic;
     public final EntityPlayer player;
     public final World world;
     public final File file;
+    @Nullable
+    public final String format;
 
     public final int minX;
     public final int maxX;
@@ -32,11 +36,12 @@ public class SchematicContainer {
     public final int chunkCount;
     public int processedChunks;
 
-    public SchematicContainer(final ISchematic schematic, final EntityPlayer player, final World world, final File file, final int minX, final int maxX, final int minY, final int maxY, final int minZ, final int maxZ) {
+    public SchematicContainer(final ISchematic schematic, final EntityPlayer player, final World world, final File file, @Nullable final String format, final int minX, final int maxX, final int minY, final int maxY, final int minZ, final int maxZ) {
         this.schematic = schematic;
         this.player = player;
         this.world = world;
         this.file = file;
+        this.format = format;
 
         this.minX = minX;
         this.maxX = maxX;

--- a/src/main/java/com/github/lunatrius/schematica/world/schematic/SchematicAlpha.java
+++ b/src/main/java/com/github/lunatrius/schematica/world/schematic/SchematicAlpha.java
@@ -210,4 +210,14 @@ public class SchematicAlpha extends SchematicFormat {
 
         return true;
     }
+
+    @Override
+    public String getName() {
+        return Names.Formats.ALPHA;
+    }
+
+    @Override
+    public String getExtension() {
+        return Names.Extensions.SCHEMATIC;
+    }
 }

--- a/src/main/java/com/github/lunatrius/schematica/world/schematic/SchematicClassic.java
+++ b/src/main/java/com/github/lunatrius/schematica/world/schematic/SchematicClassic.java
@@ -1,6 +1,8 @@
 package com.github.lunatrius.schematica.world.schematic;
 
 import com.github.lunatrius.schematica.api.ISchematic;
+import com.github.lunatrius.schematica.reference.Names;
+
 import net.minecraft.nbt.NBTTagCompound;
 
 // TODO: http://minecraft.gamepedia.com/Data_values_%28Classic%29
@@ -15,5 +17,15 @@ public class SchematicClassic extends SchematicFormat {
     public boolean writeToNBT(final NBTTagCompound tagCompound, final ISchematic schematic) {
         // TODO
         return false;
+    }
+
+    @Override
+    public String getName() {
+        return Names.Formats.CLASSIC;
+    }
+
+    @Override
+    public String getExtension() {
+        return Names.Extensions.SCHEMATIC;
     }
 }

--- a/src/main/java/com/github/lunatrius/schematica/world/schematic/SchematicFormat.java
+++ b/src/main/java/com/github/lunatrius/schematica/world/schematic/SchematicFormat.java
@@ -27,11 +27,16 @@ public abstract class SchematicFormat {
     public static ISchematic readFromFile(final File file) {
         try {
             final NBTTagCompound tagCompound = SchematicUtil.readTagCompoundFromFile(file);
-            final String format = tagCompound.getString(Names.NBT.MATERIALS);
-            final SchematicFormat schematicFormat = FORMATS.get(format);
+            final SchematicFormat schematicFormat;
+            if (tagCompound.hasKey(Names.NBT.MATERIALS)) {
+                final String format = tagCompound.getString(Names.NBT.MATERIALS);
+                schematicFormat = FORMATS.get(format);
 
-            if (schematicFormat == null) {
-                throw new UnsupportedFormatException(format);
+                if (schematicFormat == null) {
+                    throw new UnsupportedFormatException(format);
+                }
+            } else {
+                schematicFormat = FORMATS.get(Names.NBT.FORMAT_STRUCTURE);
             }
 
             return schematicFormat.readFromNBT(tagCompound);
@@ -85,7 +90,8 @@ public abstract class SchematicFormat {
         // TODO?
         // FORMATS.put(Names.NBT.FORMAT_CLASSIC, new SchematicClassic());
         FORMATS.put(Names.NBT.FORMAT_ALPHA, new SchematicAlpha());
+        FORMATS.put(Names.NBT.FORMAT_STRUCTURE, new SchematicStructure());
 
-        FORMAT_DEFAULT = Names.NBT.FORMAT_ALPHA;
+        FORMAT_DEFAULT = Names.NBT.FORMAT_STRUCTURE;
     }
 }

--- a/src/main/java/com/github/lunatrius/schematica/world/schematic/SchematicFormat.java
+++ b/src/main/java/com/github/lunatrius/schematica/world/schematic/SchematicFormat.java
@@ -135,23 +135,32 @@ public abstract class SchematicFormat {
     /**
      * Gets a schematic format name translation key for the given format ID.
      *
-     * Returns null if no such format exists, and logs a warning.
+     * If an invalid format is chosen, logs a warning and returns a key stating
+     * that it's invalid.
+     *
+     * @param format The format.
      */
-    public static String getFormatName(final String id) {
-        if (!FORMATS.containsKey(id)) {
-            Reference.logger.warn("No format for schematic with id {}; returning null", new UnsupportedFormatException(id).fillInStackTrace(), id);
-            return null;
+    public static String getFormatName(final String format) {
+        if (!FORMATS.containsKey(format)) {
+            Reference.logger.warn("No format with id {}; returning invalid for name", format, new UnsupportedFormatException(format).fillInStackTrace());
+            return Names.Formats.INVALID;
         }
-        return FORMATS.get(id).getName();
+        return FORMATS.get(format).getName();
     }
 
     /**
      * Gets the extension used by the given format.
      *
-     * @param format The format (or null to use {@link #FORMAT_DEFAULT the default}).  
+     * If the format is invalid, returns the default format's extension.
+     *
+     * @param format The format (or null to use {@link #FORMAT_DEFAULT the default}).
      */
     public static String getExtension(@Nullable String format) {
         if (format == null) {
+            format = FORMAT_DEFAULT;
+        }
+        if (!FORMATS.containsKey(format)) {
+            Reference.logger.warn("No format with id {}; returning default extension", format, new UnsupportedFormatException(format).fillInStackTrace());
             format = FORMAT_DEFAULT;
         }
         return FORMATS.get(format).getExtension();

--- a/src/main/java/com/github/lunatrius/schematica/world/schematic/SchematicStructure.java
+++ b/src/main/java/com/github/lunatrius/schematica/world/schematic/SchematicStructure.java
@@ -10,6 +10,7 @@ import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.gen.structure.template.Template;
 import com.github.lunatrius.schematica.api.ISchematic;
 import com.github.lunatrius.schematica.nbt.NBTHelper;
+import com.github.lunatrius.schematica.reference.Names;
 import com.github.lunatrius.schematica.reference.Reference;
 import com.github.lunatrius.schematica.world.storage.Schematic;
 
@@ -98,5 +99,15 @@ public class SchematicStructure extends SchematicFormat {
 
         template.writeToNBT(tagCompound);
         return true;
+    }
+
+    @Override
+    public String getName() {
+        return Names.Formats.STRUCTURE;
+    }
+
+    @Override
+    public String getExtension() {
+        return Names.Extensions.STRUCTURE;
     }
 }

--- a/src/main/java/com/github/lunatrius/schematica/world/schematic/SchematicStructure.java
+++ b/src/main/java/com/github/lunatrius/schematica/world/schematic/SchematicStructure.java
@@ -1,0 +1,102 @@
+package com.github.lunatrius.schematica.world.schematic;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.entity.Entity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.gen.structure.template.Template;
+import com.github.lunatrius.schematica.api.ISchematic;
+import com.github.lunatrius.schematica.nbt.NBTHelper;
+import com.github.lunatrius.schematica.reference.Reference;
+import com.github.lunatrius.schematica.world.storage.Schematic;
+
+public class SchematicStructure extends SchematicFormat {
+    @Override
+    public ISchematic readFromNBT(final NBTTagCompound tagCompound) {
+        final ItemStack icon = SchematicUtil.getIconFromNBT(tagCompound);
+
+        final Template template = new Template();
+        template.read(tagCompound);
+
+        final Schematic schematic = new Schematic(icon,
+                template.size.getX(), template.size.getY(), template.size.getZ(), template.getAuthor());
+
+        for (Template.BlockInfo block : template.blocks) {
+            schematic.setBlockState(block.pos, block.blockState);
+            if (block.tileentityData != null) {
+                try {
+                    // This position isn't included by default
+                    block.tileentityData.setInteger("x", block.pos.getX());
+                    block.tileentityData.setInteger("y", block.pos.getY());
+                    block.tileentityData.setInteger("z", block.pos.getZ());
+
+                    final TileEntity tileEntity = NBTHelper.readTileEntityFromCompound(block.tileentityData);
+                    if (tileEntity != null) {
+                        schematic.setTileEntity(block.pos, tileEntity);
+                    }
+                } catch (final Exception e) {
+                    Reference.logger.error("TileEntity failed to load properly!", e);
+                }
+            }
+        }
+
+        // for (Template.EntityInfo entity : template.entities) {
+        //     schematic.addEntity(...);
+        // }
+
+        return schematic;
+    }
+
+    @Override
+    public boolean writeToNBT(final NBTTagCompound tagCompound, final ISchematic schematic) {
+        Template template = new Template();
+        template.size = new BlockPos(schematic.getWidth(), schematic.getHeight(), schematic.getLength());
+
+        template.setAuthor(schematic.getAuthor());
+
+        // NOTE: Can't use MutableBlockPos here because we're keeping a reference to it in BlockInfo
+        for (BlockPos pos : BlockPos.getAllInBox(BlockPos.ORIGIN, template.size.add(-1, -1, -1))) {
+            final TileEntity tileEntity = schematic.getTileEntity(pos);
+            final NBTTagCompound compound;
+            if (tileEntity != null) {
+                compound = NBTHelper.writeTileEntityToCompound(tileEntity);
+                // Tile entities in structures don't store these coords
+                compound.removeTag("x");
+                compound.removeTag("y");
+                compound.removeTag("z");
+            } else {
+                compound = null;
+            }
+
+            template.blocks.add(new Template.BlockInfo(pos, schematic.getBlockState(pos), compound));
+        }
+
+        for (Entity entity : schematic.getEntities()) {
+            try {
+                // Entity positions are already offset via NBTHelper.reloadEntity
+                Vec3d vec3d = new Vec3d(entity.posX, entity.posY, entity.posZ);
+                NBTTagCompound nbttagcompound = new NBTTagCompound();
+                entity.writeToNBTOptional(nbttagcompound);
+                BlockPos blockpos;
+
+                // TODO: Vanilla has a check like this, but we don't; this doesn't seem to
+                // cause any problems though.
+                // if (entity instanceof EntityPainting) {
+                //     blockpos = ((EntityPainting)entity).getHangingPosition().subtract(startPos);
+                // } else {
+                blockpos = new BlockPos(vec3d);
+                // }
+
+                template.entities.add(new Template.EntityInfo(vec3d, blockpos, nbttagcompound));
+            } catch (final Throwable t) {
+                Reference.logger.error("Entity {} failed to save, skipping!", entity, t);
+            }
+        }
+
+        template.writeToNBT(tagCompound);
+        return true;
+    }
+}

--- a/src/main/java/com/github/lunatrius/schematica/world/storage/Schematic.java
+++ b/src/main/java/com/github/lunatrius/schematica/world/storage/Schematic.java
@@ -14,6 +14,8 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import javax.annotation.Nonnull;
+
 public class Schematic implements ISchematic {
     private static final ItemStack DEFAULT_ICON = new ItemStack(Blocks.GRASS);
 
@@ -25,8 +27,17 @@ public class Schematic implements ISchematic {
     private final int width;
     private final int height;
     private final int length;
+    private String author;
 
     public Schematic(final ItemStack icon, final int width, final int height, final int length) {
+        this(icon, width, height, length, "");
+    }
+
+    public Schematic(final ItemStack icon, final int width, final int height, final int length, @Nonnull final String author) {
+        if (author == null) {
+            throw new IllegalArgumentException("Author cannot be null");
+        }
+
         this.icon = icon;
         this.blocks = new short[width][height][length];
         this.metadata = new byte[width][height][length];
@@ -34,6 +45,8 @@ public class Schematic implements ISchematic {
         this.width = width;
         this.height = height;
         this.length = length;
+
+        this.author = author;
     }
 
     @Override
@@ -183,5 +196,19 @@ public class Schematic implements ISchematic {
         final int z = pos.getZ();
 
         return !(x < 0 || y < 0 || z < 0 || x >= this.width || y >= this.height || z >= this.length);
+    }
+
+    @Override
+    @Nonnull
+    public String getAuthor() {
+        return this.author;
+    }
+
+    @Override
+    public void setAuthor(@Nonnull final String author) {
+        if (author == null) {
+            throw new IllegalArgumentException("Author cannot be null");
+        }
+        this.author = author;
     }
 }

--- a/src/main/resources/META-INF/schematica_at.cfg
+++ b/src/main/resources/META-INF/schematica_at.cfg
@@ -10,3 +10,7 @@ public net.minecraft.client.renderer.chunk.RenderChunk func_178584_a(Lnet/minecr
 public net.minecraft.client.renderer.ViewFrustum func_178161_a(Lnet/minecraft/util/math/BlockPos;)Lnet/minecraft/client/renderer/chunk/RenderChunk; # getRenderChunk
 
 public net.minecraft.nbt.NBTTagCompound func_150298_a(Ljava/lang/String;Lnet/minecraft/nbt/NBTBase;Ljava/io/DataOutput;)V # writeNamedTag
+
+public net.minecraft.world.gen.structure.template.Template field_186270_a # blocks
+public net.minecraft.world.gen.structure.template.Template field_186271_b # entities
+public net.minecraft.world.gen.structure.template.Template field_186272_c # size

--- a/src/main/resources/assets/schematica/lang/en_us.lang
+++ b/src/main/resources/assets/schematica/lang/en_us.lang
@@ -23,6 +23,7 @@ schematica.gui.point.red=Red point
 schematica.gui.point.blue=Blue point
 schematica.gui.save=Save
 schematica.gui.saveselection=Save the selection as a schematic
+schematica.gui.format=Format: %s
 
 # gui - general - control
 schematica.gui.moveschematic=Move schematic
@@ -180,3 +181,8 @@ schematica.message.togglePrinter=Printer: %s
 schematica.message.invalidBlock="%s" does not exist.
 schematica.message.invalidProperty="%s" is not a valid property.
 schematica.message.invalidPropertyForBlock="%s" is not a valid property for "%s".
+
+# schematic formats
+schematica.format.classic=Classic
+schematica.format.alpha=Alpha (standard)
+schematica.format.structure=Structure block

--- a/src/main/resources/assets/schematica/lang/en_us.lang
+++ b/src/main/resources/assets/schematica/lang/en_us.lang
@@ -142,13 +142,14 @@ schematica.key.moveHere=Move here
 schematica.key.pickBlock=Pick Block
 
 # commands - save
-schematica.command.save.usage=/schematicaSave <startX> <startY> <startZ> <endX> <endY> <endZ> <name>
+schematica.command.save.usage=/schematicaSave <startX> <startY> <startZ> <endX> <endY> <endZ> <name> [format]
 schematica.command.save.playersOnly=This command can only be used by players.
 schematica.command.save.started=Started saving %d chunks into %s.
 schematica.command.save.saveSucceeded=Successfully saved %s.
 schematica.command.save.saveFailed=There was a problem saving the schematic %s.
 schematica.command.save.quotaExceeded=You have exceeded your quota on the server. Please use /schematicaList and /schematicaRemove to remove some old schematics.
 schematica.command.save.playerSchematicDirUnavailable=There was a problem on the server and your schematic was not saved. Please contact the server administrator.
+schematica.command.save.unknownFormat=Unknown format "%s".
 
 # commands - list
 schematica.command.list.usage=/schematicaList [page]
@@ -186,3 +187,4 @@ schematica.message.invalidPropertyForBlock="%s" is not a valid property for "%s"
 schematica.format.classic=Classic
 schematica.format.alpha=Alpha (standard)
 schematica.format.structure=Structure block
+schematica.format.invalid=Invalid


### PR DESCRIPTION
### Why?

The structure format is used by vanilla (`minecraft:structure_block` is dedicated to saving/loading it).  The format contains data version information and a palette (rather than depending on raw IDs).  It's also useful for making mods that add new structures.

### What user-facing changes are there?

The save GUI now allows selecting formats (currently the only options are alpha and structure, but I designed it so that more could be added and they'd be automatically handled):

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img alt="Old save buttons" src="https://user-images.githubusercontent.com/8334194/29099684-bda773c0-7c5b-11e7-9773-a2f066f33912.png" width="100%" /></td>
<td><img alt="New save buttons" src="https://user-images.githubusercontent.com/8334194/29099683-bda4023a-7c5b-11e7-80d3-66629fdd6f00.png" width="100%" /></td>
</tr>
</table>

Also, a `[format]` parameter (optional) was added to `/schematicaSave`.

Other than that, files of either format should behave identically.

### What's not implemented?

I haven't implemented a few things.

Most importantly, I haven't touched any of the networking code, and have only minimally modified the save command (none of the other ones).  All of it assumes the default format and file extensions.

I also haven't touched structure voids.  In vanilla, structure voids indicate that a block should not be replaced and should be left as whatever block it is (by not listing a block at that position in the structure file); I haven't implemented saving them and I haven't implemented unchanged blocks from them in the printer.

### Test data

[Here's some test data](https://github.com/Lunatrius/Schematica/files/1209830/structures.zip), in schematic form and structure form (both as saved by vanilla and schematica), along with text dumps of the NBT.

If you want to try some other structures, MC itself comes with several structures: unzip the jar, and grab the contents of the `assets/minecraft/structures` folder.