### PR TITLE
Add support for rendering all layers below the current layer

### DIFF
--- a/src/main/java/com/github/lunatrius/schematica/client/gui/control/GuiSchematicControl.java
+++ b/src/main/java/com/github/lunatrius/schematica/client/gui/control/GuiSchematicControl.java
@@ -8,6 +8,7 @@ import com.github.lunatrius.schematica.client.renderer.RenderSchematic;
 import com.github.lunatrius.schematica.client.util.FlipHelper;
 import com.github.lunatrius.schematica.client.util.RotationHelper;
 import com.github.lunatrius.schematica.client.world.SchematicWorld;
+import com.github.lunatrius.schematica.client.world.SchematicWorld.LayerMode;
 import com.github.lunatrius.schematica.proxy.ClientProxy;
 import com.github.lunatrius.schematica.reference.Constants;
 import com.github.lunatrius.schematica.reference.Names;
@@ -48,8 +49,6 @@ public class GuiSchematicControl extends GuiScreenBase {
     private final String strMoveSchematic = I18n.format(Names.Gui.Control.MOVE_SCHEMATIC);
     private final String strOperations = I18n.format(Names.Gui.Control.OPERATIONS);
     private final String strUnload = I18n.format(Names.Gui.Control.UNLOAD);
-    private final String strAll = I18n.format(Names.Gui.Control.MODE_ALL);
-    private final String strLayers = I18n.format(Names.Gui.Control.MODE_LAYERS);
     private final String strMaterials = I18n.format(Names.Gui.Control.MATERIALS);
     private final String strPrinter = I18n.format(Names.Gui.Control.PRINTER);
     private final String strHide = I18n.format(Names.Gui.Control.HIDE);
@@ -87,7 +86,7 @@ public class GuiSchematicControl extends GuiScreenBase {
         this.btnUnload = new GuiButton(id++, this.width - 90, this.height - 200, 80, 20, this.strUnload);
         this.buttonList.add(this.btnUnload);
 
-        this.btnLayerMode = new GuiButton(id++, this.width - 90, this.height - 150 - 25, 80, 20, this.schematic != null && this.schematic.isRenderingLayer ? this.strLayers : this.strAll);
+        this.btnLayerMode = new GuiButton(id++, this.width - 90, this.height - 150 - 25, 80, 20, I18n.format((this.schematic != null ? this.schematic.layerMode : LayerMode.ALL).name));
         this.buttonList.add(this.btnLayerMode);
 
         this.nfLayer = new GuiNumericField(this.fontRenderer, id++, this.width - 90, this.height - 150, 80, 20);
@@ -123,7 +122,7 @@ public class GuiSchematicControl extends GuiScreenBase {
 
         this.btnUnload.enabled = this.schematic != null;
         this.btnLayerMode.enabled = this.schematic != null;
-        this.nfLayer.setEnabled(this.schematic != null && this.schematic.isRenderingLayer);
+        this.nfLayer.setEnabled(this.schematic != null && this.schematic.layerMode != LayerMode.ALL);
 
         this.btnHide.enabled = this.schematic != null;
         this.btnMove.enabled = this.schematic != null;
@@ -180,9 +179,9 @@ public class GuiSchematicControl extends GuiScreenBase {
                 Schematica.proxy.unloadSchematic();
                 this.mc.displayGuiScreen(this.parentScreen);
             } else if (guiButton.id == this.btnLayerMode.id) {
-                this.schematic.isRenderingLayer = !this.schematic.isRenderingLayer;
-                this.btnLayerMode.displayString = this.schematic.isRenderingLayer ? this.strLayers : this.strAll;
-                this.nfLayer.setEnabled(this.schematic.isRenderingLayer);
+                this.schematic.layerMode = LayerMode.next(this.schematic.layerMode);
+                this.btnLayerMode.displayString = I18n.format(this.schematic.layerMode.name);
+                this.nfLayer.setEnabled(this.schematic.layerMode != LayerMode.ALL);
                 RenderSchematic.INSTANCE.refresh();
             } else if (guiButton.id == this.nfLayer.id) {
                 this.schematic.renderingLayer = this.nfLayer.getValue();
@@ -241,7 +240,6 @@ public class GuiSchematicControl extends GuiScreenBase {
         drawCenteredString(this.fontRenderer, this.strMoveSchematic, this.centerX, this.centerY - 45, 0xFFFFFF);
         drawCenteredString(this.fontRenderer, this.strMaterials, 50, this.height - 85, 0xFFFFFF);
         drawCenteredString(this.fontRenderer, this.strPrinter, 50, this.height - 45, 0xFFFFFF);
-        drawCenteredString(this.fontRenderer, this.strLayers, this.width - 50, this.height - 165, 0xFFFFFF);
         drawCenteredString(this.fontRenderer, this.strOperations, this.width - 50, this.height - 120, 0xFFFFFF);
 
         drawString(this.fontRenderer, this.strX, this.centerX - 65, this.centerY - 24, 0xFFFFFF);

--- a/src/main/java/com/github/lunatrius/schematica/client/printer/SchematicPrinter.java
+++ b/src/main/java/com/github/lunatrius/schematica/client/printer/SchematicPrinter.java
@@ -112,15 +112,20 @@ public class SchematicPrinter {
         final int slot = player.inventory.currentItem;
         final boolean isSneaking = player.isSneaking();
 
-        final boolean isRenderingLayer = this.schematic.isRenderingLayer;
-        final int renderingLayer = this.schematic.renderingLayer;
-
-        if (isRenderingLayer) {
-            if (renderingLayer > maxY || renderingLayer < minY) {
+        switch (schematic.layerMode) {
+        case ALL: break;
+        case SINGLE_LAYER:
+            if (schematic.renderingLayer > maxY) {
                 return false;
             }
-
-            minY = maxY = renderingLayer;
+            maxY = schematic.renderingLayer;
+            //$FALL-THROUGH$
+        case ALL_BELOW:
+            if (schematic.renderingLayer < minY) {
+                return false;
+            }
+            maxY = schematic.renderingLayer;
+            break;
         }
 
         syncSneaking(player, true);

--- a/src/main/java/com/github/lunatrius/schematica/client/renderer/chunk/overlay/RenderOverlay.java
+++ b/src/main/java/com/github/lunatrius/schematica/client/renderer/chunk/overlay/RenderOverlay.java
@@ -99,7 +99,7 @@ public class RenderOverlay extends RenderChunk {
             // Build the type array (including the padding)
             BlockPos.MutableBlockPos mcPos = new BlockPos.MutableBlockPos();
             for (final BlockPos.MutableBlockPos pos : BlockPos.getAllInBoxMutable(fromEx, toEx)) {
-                if (schematic.isRenderingLayer && schematic.renderingLayer != pos.getY() || !schematic.isInside(pos)) {
+                if (!schematic.isInside(pos) || !schematic.layerMode.shouldUseLayer(schematic, pos.getY())) {
                     continue;
                 }
 

--- a/src/main/java/com/github/lunatrius/schematica/client/util/BlockList.java
+++ b/src/main/java/com/github/lunatrius/schematica/client/util/BlockList.java
@@ -37,7 +37,7 @@ public class BlockList {
         final MBlockPos mcPos = new MBlockPos();
 
         for (final MBlockPos pos : BlockPosHelper.getAllInBox(BlockPos.ORIGIN, new BlockPos(world.getWidth() - 1, world.getHeight() - 1, world.getLength() - 1))) {
-            if (world.isRenderingLayer && pos.getY() != world.renderingLayer) {
+            if (!world.layerMode.shouldUseLayer(world, pos.getY())) {
                 continue;
             }
 

--- a/src/main/java/com/github/lunatrius/schematica/handler/client/InputHandler.java
+++ b/src/main/java/com/github/lunatrius/schematica/handler/client/InputHandler.java
@@ -6,6 +6,7 @@ import com.github.lunatrius.schematica.client.gui.save.GuiSchematicSave;
 import com.github.lunatrius.schematica.client.printer.SchematicPrinter;
 import com.github.lunatrius.schematica.client.renderer.RenderSchematic;
 import com.github.lunatrius.schematica.client.world.SchematicWorld;
+import com.github.lunatrius.schematica.client.world.SchematicWorld.LayerMode;
 import com.github.lunatrius.schematica.proxy.ClientProxy;
 import com.github.lunatrius.schematica.reference.Names;
 import net.minecraft.client.Minecraft;
@@ -70,7 +71,7 @@ public class InputHandler {
 
             if (KEY_BINDING_LAYER_INC.isPressed()) {
                 final SchematicWorld schematic = ClientProxy.schematic;
-                if (schematic != null && schematic.isRenderingLayer) {
+                if (schematic.layerMode != LayerMode.ALL) {
                     schematic.renderingLayer = MathHelper.clamp(schematic.renderingLayer + 1, 0, schematic.getHeight() - 1);
                     RenderSchematic.INSTANCE.refresh();
                 }
@@ -78,7 +79,7 @@ public class InputHandler {
 
             if (KEY_BINDING_LAYER_DEC.isPressed()) {
                 final SchematicWorld schematic = ClientProxy.schematic;
-                if (schematic != null && schematic.isRenderingLayer) {
+                if (schematic.layerMode != LayerMode.ALL) {
                     schematic.renderingLayer = MathHelper.clamp(schematic.renderingLayer - 1, 0, schematic.getHeight() - 1);
                     RenderSchematic.INSTANCE.refresh();
                 }
@@ -87,7 +88,7 @@ public class InputHandler {
             if (KEY_BINDING_LAYER_TOGGLE.isPressed()) {
                 final SchematicWorld schematic = ClientProxy.schematic;
                 if (schematic != null) {
-                    schematic.isRenderingLayer = !schematic.isRenderingLayer;
+                    schematic.layerMode = LayerMode.next(schematic.layerMode);
                     RenderSchematic.INSTANCE.refresh();
                 }
             }

--- a/src/main/java/com/github/lunatrius/schematica/reference/Names.java
+++ b/src/main/java/com/github/lunatrius/schematica/reference/Names.java
@@ -166,6 +166,7 @@ public final class Names {
             public static final String UNLOAD = "schematica.gui.unload";
             public static final String MODE_ALL = "schematica.gui.all";
             public static final String MODE_LAYERS = "schematica.gui.layers";
+            public static final String MODE_BELOW = "schematica.gui.below";
             public static final String HIDE = "schematica.gui.hide";
             public static final String SHOW = "schematica.gui.show";
             public static final String MOVE_HERE = "schematica.gui.movehere";

--- a/src/main/resources/assets/schematica/lang/en_us.lang
+++ b/src/main/resources/assets/schematica/lang/en_us.lang
@@ -33,6 +33,7 @@ schematica.gui.operations=Operations
 schematica.gui.unload=Unload
 schematica.gui.all=ALL
 schematica.gui.layers=Layers
+schematica.gui.below=All below
 schematica.gui.hide=Hide
 schematica.gui.show=Show
 schematica.gui.movehere=Move here


### PR DESCRIPTION
For #288.

![2017-11-16_17 50 10](https://user-images.githubusercontent.com/8334194/32925535-3b445322-caf7-11e7-8b8e-eba1bb4e46d5.png)

Adds a new mode option that renders all layers below the current layer (in addition to the current layer).  Also reworks the layer code to allow more options (it's an `enum` now rather than a simple boolean).

This works with the printer, and can be used both in the control GUI and via a hotkey (if configured).

Does not add an all above mode.  It wouldn't be too hard to add one if that seemed useful, but building downward is not a frequent activity and I don't think such a mode would be useful.